### PR TITLE
Add style to center and shrink images in docs

### DIFF
--- a/_sass/minimal-mistakes/_page.scss
+++ b/_sass/minimal-mistakes/_page.scss
@@ -70,6 +70,13 @@ body {
     .page__error {
       text-align: center;
     }
+    
+    /* This `img` style applies only to .png and .jpg files (added by josh-wong) */
+    img[src$=".png"], img[src$=".jpg"] {
+      max-height: 400px;
+      margin: auto;
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
## Related issue

**If applicable, please provide a link to the issue related to this change.**

- [ ] **Related issue:** [URL]
- [x] **No related issue**

## Description

**Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.**

This PR adds a style for .png and .jpg images within the body of a document. Since the Jekyll theme originally did not include a style for images on a page, images were aligned to the left and often took up more space on the page than necessary.

This style centers .png and .jpg images within the document and restricts the height of the images to a maximum of 400px. 

### Type of change

- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (an improvement to the existing state)
- [ ] This change requires a documentation update

## How has this been tested?

**Please describe the tests that you ran to verify your changes and provide instructions so that we can reproduce. Please also list any relevant details for your test configuration.**

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and checked a variety of image sizes (those larger in height and those larger in width). Those images were displayed as centered and at a set max height of 400px, as specified in the `_page.scss` file.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
