### PR TITLE
Add Google and Bing site verification for better search engine indexing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,8 +33,8 @@ lunr:
   search_within_pages: true
 
 # SEO Related
-google_site_verification : # Replace this with your ID, or delete; not necessary since we have included our Google Analytics tracking ID
-bing_site_verification   : # Replace this with your ID, or delete
+google_site_verification : f4A1_o8ea-_b8wsvLMeTii2rmUpHU3veODTLjFZGL50 # Replace this with your ID, or delete; not necessary since we have included our Google Analytics tracking ID
+bing_site_verification   : FF58F572E4C7F663AFCCC989725A581D # Replace this with your ID, or delete
 
 # Social Sharing
 twitter:


### PR DESCRIPTION
## Description

This PR adds a IDs for Google and Bing to verify site ownership. Claiming ownership improves SEO and site indexing/crawling.

### Related issue or PR

N/A

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Ensured the site deployed as expected. After the site is deployed, I can verify the site through Google Search Console and Bing Webmaster Tools.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
