### PR TITLE
Add support for tabbed content

### DIFF
--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -1,3 +1,4 @@
 <!-- start custom footer snippets -->
-
+<!-- Added to support tabbed content (added by josh-wong) -->
+<script src="/assets/js/tabbed-content.js"></script>
 <!-- end custom footer snippets -->

--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -29,6 +29,7 @@
 @import "minimal-mistakes/footer";
 @import "minimal-mistakes/search";
 @import "minimal-mistakes/syntax";
+@import "minimal-mistakes/tabbed-content"; /* Added to support tabbed content (added by josh-wong) */
 
 /* Utility classes */
 @import "minimal-mistakes/utilities";

--- a/_sass/minimal-mistakes/_tabbed-content.scss
+++ b/_sass/minimal-mistakes/_tabbed-content.scss
@@ -1,0 +1,49 @@
+/* ==========================================================================
+   Tabbed content (added by josh-wong)
+   ========================================================================== */
+
+/* Style the tab */
+.tab {
+  overflow: hidden;
+  background-color: transparent;
+}
+
+/* Style the buttons inside the tab */
+.tab button {
+  background-color: transparent;
+  float: left;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 14px 16px;
+  font-size: $doc-font-size;
+  font-weight: 600;
+  color: inherit;
+}
+
+/* Change background color of buttons on hover */
+.tab button:hover {
+  color: $scalar-primary-color;
+  background-color: $scalar-light-gray-background-color;
+  border-bottom: 4px solid $scalar-primary-color;
+}
+
+/* Create an active/current tablink class */
+.tab button.active {
+  color: white;
+  background-color: $scalar-primary-color;
+  border-bottom: 4px solid $scalar-primary-color;
+  transition: 0s;
+}
+
+/* Style the tab content */
+.tabcontent {
+  display: none;
+  padding-top: 25px;
+  border-top: 1px solid $lighter-gray;
+
+  & img {
+    margin: auto;
+    display: block;
+  }
+}

--- a/assets/js/tabbed-content.js
+++ b/assets/js/tabbed-content.js
@@ -1,0 +1,36 @@
+/* ==========================================================================
+   Tabbed content support (added by josh-wong)
+   ========================================================================== */
+function openTab(evt, tabName, setName) {    
+  var i, tabcontent, tablinks;
+
+  var set = document.getElementById(setName);
+
+  // Clear the previously selected tab.
+  tabcontent = set.getElementsByClassName("tabcontent");
+  for (i = 0; i < tabcontent.length; i++) {
+      tabcontent[i].style.display = "none";
+  }
+
+  // Set the tab to "active".
+  tablinks = set.getElementsByClassName("tablinks");
+  for (i = 0; i < tablinks.length; i++) {
+      tablinks[i].className = tablinks[i].className.replace(" active", "");
+  }
+
+  // Display the selected tab and set it to active.
+  document.getElementById(tabName).style.display = "block";
+  evt.currentTarget.className += " active";
+}
+
+// Get the element with id="defaultOpen" and click on it.
+document.getElementById("defaultOpen-1").click();
+document.getElementById("defaultOpen-2").click();
+document.getElementById("defaultOpen-3").click();
+document.getElementById("defaultOpen-4").click();
+document.getElementById("defaultOpen-5").click();
+document.getElementById("defaultOpen-6").click();
+document.getElementById("defaultOpen-7").click();
+document.getElementById("defaultOpen-8").click();
+document.getElementById("defaultOpen-9").click();
+document.getElementById("defaultOpen-10").click();


### PR DESCRIPTION
## Description

This PR adds support for HTML-based tabs in Markdown pages. 

Since there is no native way within our theme to add tabs, we decided to implement a function to do so that we can make pages easier to read and maintain. In addition, tabs allow users to seamlessly switch between multiple types of content without moving to a different page.

### Related issue or PR

N/A

### Type of change

- [ ] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [X] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and navigated to a test page that included multiple sets of tabbed content, and ensured that all tabs were visible and that each tab showed the correct contents.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
