### PR TITLE
Add a Releases category to the side navigation and add individual release notes from ScalarDL 3.4 to 3.8

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -261,6 +261,20 @@ defaults:
       toc_sticky: true
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
   
+  # Release notes
+  - scope:
+      path: "docs/releases" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
   # Hides ScalarDB-related pages (e.g., Helm Charts docs) from search results.
   # NOTE: The following method causes a lengthy build time, which occasionally causes the build to remain "In progress" indefinitely. Because of that, it is currently commented out until we find an alternative way to hide specific pages from search results.
   # - scope:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -141,6 +141,23 @@ versions:
         url: /docs/latest/implementation/
       - title: "ScalarDL Benchmarks"
         url: /docs/latest/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.7":
   - title: "⬅ ScalarDL docs home" 
@@ -228,6 +245,23 @@ versions:
         url: /docs/3.7/implementation/
       - title: "ScalarDL Benchmarks"
         url: /docs/3.7/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.6":
   - title: "⬅ ScalarDL docs home" 
@@ -315,6 +349,23 @@ versions:
         url: /docs/3.6/implementation/
       - title: "ScalarDL Benchmarks"
         url: /docs/3.6/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.5":
   - title: "⬅ ScalarDL docs home" 
@@ -402,6 +453,23 @@ versions:
         url: /docs/3.5/implementation/
       - title: "ScalarDL Benchmarks"
         url: /docs/3.5/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
 
 "3.4":
   - title: "⬅ ScalarDL docs home" 
@@ -489,3 +557,20 @@ versions:
         url: /docs/3.4/implementation/
       - title: "ScalarDL Benchmarks"
         url: /docs/3.4/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,13 @@
+---
+toc: false
+---
+
+# Release Notes
+
+Select a version to see the release notes:
+
+- [ScalarDL 3.8](release-3.8.md)
+- [ScalarDL 3.7](release-3.7.md)
+- [ScalarDL 3.6](release-3.6.md)
+- [ScalarDL 3.5](release-3.5.md)
+- [ScalarDL 3.4](release-3.4.md)

--- a/docs/releases/release-3.4.md
+++ b/docs/releases/release-3.4.md
@@ -1,0 +1,106 @@
+# ScalarDL 3.4 Release Notes
+
+This page includes a list of release notes for ScalarDL 3.4.
+
+## 3.4.5
+
+**Release date:** April 18, 2023
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.11.
+- Updated the in-house JRE Docker image to 1.1.12.
+- Updated the in-house JRE image to 1.1.10.
+- Updated the version of gRPC health probe to 0.4.15.
+- Used the latest version of Ubuntu.
+
+## 3.4.5
+
+**Release date:** January 6, 2023
+
+### Improvements
+
+- Updated the in-house JRE Docker image.
+- Updated the version of ScalarDB.
+
+## 3.4.4
+
+**Release date:** December 2, 2022
+
+### Improvements
+
+- Added `FunctionManager` to make `Function` mockable.
+
+### Bug fixes
+
+- Fixed [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149").
+- Fixed [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff) and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4).
+- Fixed [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622).
+- Added [@OverRide](https://github.com/OverRide) to fix a warning from ErrorProne.
+
+## 3.4.3
+
+**Release date:** September 22, 2022
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.8.
+- Updated the in-house JRE 8 Docker image to 1.1.7.
+- Updated JRE 8 to 1.1.6.
+- Updated JRE 8 to 1.1.5.
+
+## 3.4.2
+
+**Release date:** August 3, 2022
+
+### Improvements
+
+- Updated the internal JRE Docker image to 1.1.3.
+- Updated the internal JRE Docker image to 1.1.4.
+
+## 3.4.1
+
+**Release date:** June 21, 2022
+
+### Improvements
+
+- Added a `USER 201` setting in the Dockerfile to run as a non-root user.
+- Updated the version of ScalarDB to 3.5.2.
+- Updated the internal JRE Docker base image to 1.1.2.
+- Updated the base image JRE 8 to 1.1.0.
+
+### Bug fixes
+
+- Fixed [CVE-2022-27191](https://github.com/advisories/GHSA-8c26-wmh5-6g9v).
+
+## 3.4.0
+
+**Release date:** February 22, 2022
+
+### Improvements
+
+- Used an internal JRE 8 image to avoid patching in Dockerfile.
+- Added crashing SmallBank application in GitHub Action.
+- Specified the Cassandra container to not be deleted if a inconsistent state error happens.
+- Redirected the ledger and auditor's logs to files.
+- Made preservation of input data configurable.
+- Improved configuration-related aspects by adding more comments, fixing scopes, and fixing minor issues.
+- Updated the `ValidateLedger` contract and the BFD test for the linearizable ledger validation.
+- Upgraded the version of ScalarDB.
+- Made logging in mandatory before being able to pull a JRE container.
+
+### Bug fixes
+
+- Upgraded Log4j to address. [CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
+- Updated the version of Log4j to 2.17.0.
+- Fixed multi-byte handling.
+- Updated the versions of gRPC and protoc to fix a vulnerability issue.
+- Added a permission configuration for the Cosmos DB driver.
+- Updated the version of `grpc_health_probe` to fix a vulnerability issue.
+- Fixed a false-positive inconsistency bug.
+- Updated the version of Log4j to 2.17.1.
+- Made scan in a contract work even with Auditor.
+- Avoided scanning and writing in a contract even with Auditor.
+- Fixed bugs and incomplete tests around `LedgerSimulator`.
+- Refactored scan in Auditor.
+- Fixed `validateLedger`.

--- a/docs/releases/release-3.5.md
+++ b/docs/releases/release-3.5.md
@@ -1,0 +1,139 @@
+# ScalarDL 3.5 Release Notes
+
+This page includes a list of release notes for ScalarDL 3.5.
+
+## 3.5.7
+
+**Release date:** April 18, 2023
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.11.
+- Updated the in-house JRE Docker image to 1.1.12.
+- Updated the in-house JRE image to 1.1.10.
+- Updated the version of gRPC health probe to 0.4.15.
+- Used the latest version of Ubuntu.
+
+### Bug fixes
+
+- Added a fix to verify signatures when reading them from Ledger.
+
+## 3.5.6
+
+**Release date:** January 6, 2023
+
+### Improvements
+
+- Updated the in-house JRE Docker image.
+- Updated the version of ScalarDB.
+
+## 3.5.5
+
+**Release date:** December 2, 2022
+
+### Improvements
+
+- Added `FunctionManager` to make `Function` mockable.
+
+### Bug fixes
+
+- Used scannable `LedgerTracer` that does storage scan in a `Contract`.
+- Fixed [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622).
+- Added `FunctionManager` to make `Function` mockable.
+- Fixed [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff) and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4).
+- Fixed [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp).
+- Added [@OverRide](https://github.com/OverRide) to fix a warning from ErrorProne.
+- Updated the version of gRPC to fix a vulnerability.
+
+## 3.5.4
+
+**Release date:** September 22, 2022
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.7.
+- Updated the in-house JRE 8 Docker image to 1.1.8.
+
+### Bug fixes
+
+- Fixed Ledger/Auditor/Client configuration loading.
+
+## 3.5.3
+
+**Release date:** August 19, 2022
+
+### Bug fixes
+
+- Fix validation in Ledger-only mode with the V2 argument.
+
+## 3.5.2
+
+**Release date:** August 17, 2022
+
+### Improvements
+
+- Updated the Javadocs for `ClientService`.
+- Put `AbstractRequest` back to the client JAR.
+
+### Bug fixes
+
+- Fixed the camel case fields.
+- Fixed the contract argument handling in DagValidator.
+
+## 3.5.1
+
+**Release date:** August 10, 2022
+
+### Improvements
+
+- Updated JRE 8 to 1.1.6.
+
+### Bug fixes
+
+- Fixed the degradation of contract properties handling.
+
+## 3.5.0
+
+**Release date:** August 3, 2022
+
+### Enhancements (backward compatible)
+
+- Added a new Ledger interface that matches the new contract I/F.
+- Added a Jackson-based contract and ledger.
+- Used `DeprecatedLedgerReturnable` for deprecated classes.
+- Exposed JSON libraries for applications to call `ClientService` APIs.
+- Added E2E tests for checking backward compatibility in the new Contract/Ledger interface.
+- Changed to the `master` branch.
+- Used Jackson for internal JSON processing.
+- Used static SerDe.
+- Revived the old `AssetProof` and used it for backward compatibility.
+- Implemented V2 format for JsonNode-based arguments.
+- Renamed `JavaxJson` to `Jsonp`.
+- Fixed `LedgerTracerManager` for Jackson.
+- Updated the client JAR.
+- Introduced a contract context to pass runtime information from contracts to functions.
+- Restricted Functions from being cached since Functions are not thread safe.
+- Refactored `ClientConfig` and `ClientServiceFactory`.
+- Fixed smallbank.
+- Fixed scan for new Ledger interfaces.
+- Allowed the execution of a contract that has scan and put.
+- Fixed backward-incompatible issue in contract argument processing.
+- Fixed function ID extraction bug.
+- Made storing the data of input dependencies not configurable.
+- Updated Javadocs.
+- Updated based on SpotBugs warnings.
+
+### Improvements
+
+- Added an administrator interface to Auditor.
+- Renamed `Assetbase` to `AssetLedger` and `assetbase` to `ledger`.
+- Refactored `AuditorConfig`.
+- Fixed warnings from `ErrorProne`.
+- Restricted the pushing of unused containers.
+- Fixed unnecessary `toString()`.
+- Upgraded the version of ScalarDB.
+
+### Bug fixes
+
+- Updated the internal JRE Docker image to 1.1.3.
+- Updated the internal JRE Docker image to 1.1.4.

--- a/docs/releases/release-3.6.md
+++ b/docs/releases/release-3.6.md
@@ -1,0 +1,61 @@
+# ScalarDL 3.6 Release Notes
+
+This page includes a list of release notes for ScalarDL 3.6.
+
+## 3.6.4
+
+**Release date:** April 18, 2023
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.11.
+- Updated the in-house JRE Docker image to 1.1.12.
+- Updated the in-house JRE image to 1.1.10.
+- Updated the version of gRPC health probe to 0.4.15.
+- Used the latest version of Ubuntu.
+
+### Bug fixes
+
+- Added a fix to verify signatures when reading them from Ledger.
+
+## 3.6.3
+
+**Release date:** January 6, 2023
+
+### Improvements
+
+- Updated the in-house JRE Docker image.
+- Updated the version of ScalarDB.
+
+## 3.6.2
+
+**Release date:** December 2, 2022
+
+### Improvements
+
+- Added `FunctionManager` to make `Function` mockable.
+- Used scannable `LedgerTracer` that does storage scan in a `Contract`.
+- Updated the version of ScalarDB.
+
+### Bug fixes
+
+- Fixed [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149").
+- Fixed [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff) and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4).
+- Added [@OverRide](https://github.com/OverRide) to fix a warning from ErrorProne.
+- Fixed [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622).
+- Updated the version of gRPC to fix a vulnerability.
+
+## 3.6.0
+
+**Release date:** September 22, 2022
+
+### Enhancements
+
+- Updated the release workflow to push the container to the Elastic Container Registry on AWS Marketplace.
+- Upgraded the version of ScalarDB.
+
+### Bug fixes
+
+- Updated the in-house JRE 8 Docker image to 1.1.7.
+- Updated the in-house JRE 8 Docker image to 1.1.8.
+- Fixed Ledger/Auditor/Client configuration loading.

--- a/docs/releases/release-3.7.md
+++ b/docs/releases/release-3.7.md
@@ -1,0 +1,58 @@
+# ScalarDL 3.7 Release Notes
+
+This page includes a list of release notes for ScalarDL 3.7.
+
+## 3.7.2
+
+**Release date:** April 18, 2023
+
+### Improvements
+
+- Updated the in-house JRE 8 Docker image to 1.1.11.
+- Updated the in-house JRE Docker image to 1.1.12.
+- Updated the in-house JRE image to 1.1.10.
+- Updated the version of gRPC health probe to 0.4.15.
+- Used the latest version of Ubuntu.
+
+### Bug fixes
+
+- Added a fix to verify signatures when reading them from Ledger.
+- Fixed thread unsafety in Ledger validation.
+
+## 3.7.1
+
+**Release date:** January 6, 2023
+
+### Improvements
+
+- Updated the in-house JRE Docker image.
+- Updated the version of ScalarDB.
+
+
+## 3.7.0
+
+**Release date:** December 2, 2022
+
+### Enhancements
+
+- Made `Asset` be able to return `AssetMetadata` that includes some internal metadata.
+- Added a transaction asset scanner to scan Ledger assets.
+- Added a transaction scannable tracer manager.
+
+### Improvements
+
+- Made `AssetInput` not manage data.
+- Renamed classes, such as `AuditorAssetScanner`.
+- Revised `ContractsRegistration` and `FunctionsRegistration`.
+- Added more sources to the SDK.
+
+### Bug fixes
+
+- Added `FunctionManager` to make `Function` mockable.
+- Used scannable LedgerTracer that does storage scan in a Contract.
+- Fixed [CVE-2022-27664](https://github.com/advisories/GHSA-69cg-p879-7622).
+- Fixed [CVE-2022-32149](https://github.com/advisories/GHSA-69ch-w2m2-3vjp "CVE-2022-32149").
+- Fixed [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff) and [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4).
+- Updated the version of gRPC to fix a vulnerability.
+- Added [@OverRide](https://github.com/OverRide) to fix a warning from ErrorProne.
+- Upgraded the version of ScalarDB.

--- a/docs/releases/release-3.8.md
+++ b/docs/releases/release-3.8.md
@@ -1,0 +1,27 @@
+# ScalarDL 3.8 Release Notes
+
+This page includes a list of release notes for ScalarDL 3.8.
+
+## 3.8.0
+
+**Release date:** April 19, 2023
+
+### New features
+
+- Added support for hash-based message authentication codes (HMACs). In ScalarDL 3.7 and earlier versions, you could use only digital signatures as the authentication method between client and Ledger, client and Auditor, and Ledger and Auditor. As of ScalarDL 3.8, you can use either digital signatures or HMACs for all authentications. By default, digital signatures are used for authentication.
+- Added capability to configure values through environment variables. As of ScalarDL 3.8, you can set values for Client SDK, Ledger, and Auditor configurations through environment variables. This capability enables you to more flexibly and easily configure Client SDK, Ledger and Auditor.
+- Added metering capability for pay-as-you-go in the AWS Marketplace. As of ScalarDL 3.8, you can download and use container images of ScalarDL Ledger and Auditor through the AWS Marketplace. You will be automatically billed a fee based on how many hours you use each container.
+
+For more details, please see [ScalarDL 3.8 has been released!](https://medium.com/scalar-engineering/scalardl-3-8-has-been-released-40ed12242d6c)
+
+### Improvements
+
+- Added a cache for DagValidator to reduce validation time by avoiding duplicate contract execution in Auditor.
+- Renamed `Scalar DL` to `ScalarDL` for product branding purposes.
+- Removed unnecessary code and files.
+- Upgraded the supported version of ScalarDB from 3.7.2 to 3.8.0.
+
+### Bug fixes
+
+- Upgraded the integrated Java Runtime Environment (JRE) Docker image to 1.1.12 to fix security issues. [CVE-2023-0286](https://nvd.nist.gov/vuln/detail/CVE-2023-0286), [CVE-2023-0361](https://nvd.nist.gov/vuln/detail/CVE-2023-0361)
+- Upgraded gRPC Health Probe to 0.4.17 to fix security issues. [CVE-2022-41721](https://nvd.nist.gov/vuln/detail/CVE-2022-41721), [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/cve-2022-41723)


### PR DESCRIPTION
## Description

This PR adds a Releases category to the side navigation and adds individual release notes for ScalarDL 3.4 to 3.8.

### Related issue or PR

N/A

### Type of change

- [x] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, visited the new pages, and confirmed that the content appeared as expected. Also confirmed that the side navigation worked as expected with the new Releases category.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
