### PR TITLE
Add updated docs for Scalar Kubernetes

### DIFF
--- a/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/3.4/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.4/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.4/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/3.4/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.4/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.5/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/3.5/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.5/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/3.5/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.5/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/3.5/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.5/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.5/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.5/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.5/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/3.5/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.5/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/3.5/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.5/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/3.5/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.5/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/3.5/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.5/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.5/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.5/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.6/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.6/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/3.6/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.6/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/3.6/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.6/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/3.6/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.6/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.6/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.6/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.6/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/3.6/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.6/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/3.6/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.6/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/3.6/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.6/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/3.6/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.6/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.6/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.6/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.7/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.7/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/3.7/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.7/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/3.7/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.7/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/3.7/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.7/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.7/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.7/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.7/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/3.7/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.7/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/3.7/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.7/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/3.7/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.7/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/3.7/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.7/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.7/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.7/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.8/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.8/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/3.8/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.8/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/3.8/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.8/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/3.8/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.8/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.8/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.8/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.8/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/3.8/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.8/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/3.8/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.8/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/3.8/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.8/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/3.8/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.8/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/3.8/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.8/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/latest/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/latest/scalar-kubernetes/AccessScalarProducts.md
@@ -42,14 +42,19 @@ If you deploy your application (client) in the same Kubernetes cluster as Scalar
 The following are examples of ScalarDB and ScalarDL deployments on the `ns-scalar` namespace:
 
 * **ScalarDB Server**
+
     ```console
     scalardb-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Ledger**
+
     ```console
     scalardl-ledger-envoy.ns-scalar.svc.cluster.local
     ```
+
 * **ScalarDL Auditor**
+
     ```console
     scalardl-auditor-envoy.ns-scalar.svc.cluster.local
     ```
@@ -57,19 +62,24 @@ The following are examples of ScalarDB and ScalarDL deployments on the `ns-scala
 When using the Kubernetes service resource, you must set the above FQDN in the properties file for the application (client) as follows:
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
+
     ```properties
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<HELM_RELEASE_NAME>-envoy.<NAMESPACE>.svc.cluster.local
@@ -94,19 +104,23 @@ For more details on how to configure your custom values file, see [Service confi
 When using a load balancer, you must set the FQDN or IP address of the load balancer in the properties file for the application (client) as follows.
 
 * **Client properties file for ScalarDB Server**
+
     ```properties
     scalar.db.contact_points=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.db.contact_port=60051
     scalar.db.storage=grpc
     scalar.db.transaction_manager=grpc
     ```
+
 * **Client properties file for ScalarDL Ledger**
     ```properties
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
     scalar.dl.ledger.server.port=50051
     scalar.dl.ledger.server.privileged_port=50052
     ```
+
 * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
     ```properties
     # Ledger
     scalar.dl.client.server.host=<LOAD_BALANCER_FQDN_OR_IP_ADDRESS>
@@ -135,34 +149,45 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
 1. **(ScalarDL Auditor mode only)** In the bastion server for ScalarDL Ledger, configure an existing kubeconfig file or add a new kubeconfig file to access the Kubernetes cluster for ScalarDL Auditor. For details on how to configure the kubeconfig file of each managed Kubernetes cluster, see [Configure kubeconfig](./CreateBastionServer.md#configure-kubeconfig).
 2. Configure port forwarding to each service from the bastion server.
    * **ScalarDB Server**
+
      ```console
      kubectl port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 60051:60051
      ```
+
    * **ScalarDL Ledger**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50051:50051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_LEDGER> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 50052:50052
      ```
+
    * **ScalarDL Auditor**
+
      ```console
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40051:40051
      kubectl --context <CONTEXT_IN_KUBERNETES_FOR_SCALARDL_AUDITOR> port-forward -n <NAMESPACE> svc/<RELEASE_NAME>-envoy 40052:40052
      ```
+
 3. Configure the properties file to access ScalarDB or ScalarDL via `localhost`.
    * **Client properties file for ScalarDB Server**
+
      ```properties
      scalar.db.contact_points=localhost
      scalar.db.contact_port=60051
      scalar.db.storage=grpc
      scalar.db.transaction_manager=grpc
      ```
+
    * **Client properties file for ScalarDL Ledger**
+
      ```properties
      scalar.dl.client.server.host=localhost
      scalar.dl.ledger.server.port=50051
      scalar.dl.ledger.server.privileged_port=50052
      ```
+
    * **Client properties file for ScalarDL Ledger with ScalarDL Auditor mode enabled**
+
      ```properties
      # Ledger
      scalar.dl.client.server.host=localhost
@@ -175,4 +200,3 @@ You can run client requests to ScalarDB or ScalarDL from a bastion server by run
      scalar.dl.auditor.server.port=40051
      scalar.dl.auditor.server.privileged_port=40052
      ```
-

--- a/docs/latest/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/latest/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -7,9 +7,11 @@ Note that some Scalar products are available under commercial licenses, and the 
 ## Subscribe to Scalar products from AWS Marketplace
 
 1. Access to the AWS Marketplace.
+   * [ScalarDB Cluster Standard Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-jx6qxatkxuwm4)
+   * [ScalarDB Cluster Premium Edition (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-djqw3zk6dwyk6)
    * [ScalarDL Ledger (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-wttioaezp5j6e)
    * [ScalarDL Auditor (Pay-As-You-Go)](https://aws.amazon.com/marketplace/pp/prodview-ke3yiw4mhriuu)
-   * [ScalarDB (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
+   * [[Deprecated] ScalarDB Server (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-rzbuhxgvqf4d2)
    * [ScalarDL Ledger (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-3jdwfmqonx7a2)
    * [ScalarDL Auditor (BYOL)](https://aws.amazon.com/marketplace/pp/prodview-tj7svy75gu7m6)
 
@@ -55,8 +57,34 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 
    You need to specify the private container registry (ECR) of the AWS Marketplace and the version (tag) as the value for `[].image.repository` and `[].image.version (tag)` in the custom values file. You also need to specify the service account name that you created in the previous step as the value for `[].serviceAccount.serviceAccountName` and set `[].serviceAccount.automountServiceAccountToken` to `true`.
 
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition (scalardb-cluster-standard-custom-values.yaml)
+
+        ```yaml
+        scalardbCluster:
+          image:
+            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-standard"
+            tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+        ```
+
+     * ScalarDB Cluster Premium Edition (scalardb-cluster-premium-custom-values.yaml)
+
+       ```yaml
+       scalardbCluster:
+         image:
+           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-cluster-node-aws-payg-premium"
+           tag: "3.10.1"
+          serviceAccount:
+            serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
+            automountServiceAccountToken: true
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         ledger:
           image:
@@ -66,7 +94,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             serviceAccountName: "<SERVICE_ACCOUNT_NAME>"
             automountServiceAccountToken: true
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         auditor:
           image:
@@ -83,7 +113,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger-aws-payg"
             version: "3.8.0"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -92,20 +124,40 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
         ```
 
 1. Deploy Scalar products by using Helm Charts in conjunction with the above custom values files.
+   * ScalarDB Cluster Examples
+     * ScalarDB Cluster Standard Edition
+
+       ```console
+       helm install scalardb-cluster-standard scalar-labs/scalardb-cluster -f scalardb-cluster-standard-custom-values.yaml
+       ```
+
+     * ScalarDB Cluster Premium Edition
+
+       ```console
+       helm install scalardb-cluster-premium scalar-labs/scalardb-cluster -f scalardb-cluster-premium-custom-values.yaml
+       ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -118,6 +170,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    You need to specify the private container registry (ECR) of AWS Marketplace and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -131,14 +184,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -152,7 +209,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -166,14 +225,18 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalar-auditor"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
             repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardl-schema-loader-ledger"
             version: "3.4.1"
         ```
+
       * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -184,27 +247,38 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Deploy the Scalar products using the Helm Chart with the above custom values files.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Ledger)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-ledger-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader (Auditor)
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-auditor-custom-values.yaml
         ```
@@ -216,6 +290,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
 1. Configure the AWS CLI with your credentials according to the [AWS Official Document (Configuration basics)](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
 1. Create a `reg-ecr-mp-secrets` secret resource for pulling the container images from the ECR of AWS Marketplace.
+
    ```console
    kubectl create secret docker-registry reg-ecr-mp-secrets \
      --docker-server=709825985650.dkr.ecr.us-east-1.amazonaws.com \
@@ -228,6 +303,7 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
    Also, you need to specify the `reg-ecr-mp-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
        * ScalarDB Server (scalardb-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -245,7 +321,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
          ```yaml
          image:
            repository: "709825985650.dkr.ecr.us-east-1.amazonaws.com/scalar/scalardb-graphql"
@@ -253,8 +331,10 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
          imagePullSecrets:
            - name: "reg-ecr-mp-secrets"
          ```
+
    * ScalarDL Examples
        * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -272,7 +352,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
          ```yaml
          envoy:
            image:
@@ -290,7 +372,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml)
+
          ```yaml
          schemaLoading:
            image:
@@ -299,7 +383,9 @@ By subscribing to Scalar products in the AWS Marketplace, you can pull the conta
            imagePullSecrets:
              - name: "reg-ecr-mp-secrets"
          ```
+
        * ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml)
+       
          ```yaml
          schemaLoading:
            image:

--- a/docs/latest/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/latest/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -59,6 +59,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    You need to specify your private container registry and the version (tag) as the value of `[].image.repository` and `[].image.version (tag)` in the custom values file.  
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -72,14 +73,18 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalardb-server"
             tag: "3.5.2"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
           tag: "3.6.0"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -93,7 +98,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-ledger"
             version: "3.4.0"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -107,7 +114,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
             repository: "example.azurecr.io/scalarinc/scalar-auditor"
             version: "3.4.0"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+
         ```yaml
         schemaLoading:
           image:
@@ -118,23 +127,32 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Deploy the Scalar product using the Helm Chart with the above custom values file.
    * ScalarDB Examples
       * ScalarDB Server
+
         ```console
         helm install scalardb scalar-labs/scalardb -f ./scalardb-custom-values.yaml
         ```
+
       * ScalarDB GraphQL Server
+
         ```console
         helm install scalardb-graphql scalar-labs/scalardb-graphql -f scalardb-graphql-custom-values.yaml
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger
+
         ```console
         helm install scalardl-ledger scalar-labs/scalardl -f ./scalardl-ledger-custom-values.yaml
         ```
+
       * ScalarDL Auditor
+
         ```console
         helm install scalardl-auditor scalar-labs/scalardl-audit -f ./scalardl-auditor-custom-values.yaml
         ```
+
       * ScalarDL Schema Loader
+
         ```console
         helm install schema-loader scalar-labs/schema-loading -f ./schema-loader-custom-values.yaml
         ```
@@ -144,6 +162,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
 1. Install the `az` command according to the [Azure Official Document (How to install the Azure CLI)](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli).
 
 1. Sign in with Azure CLI.
+
    ```console
    az login
    ```
@@ -152,6 +171,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    We use the **Service principal ID** and the **Service principal password** in the next step.
 
 1. Create a `reg-acr-secrets` secret resource for pulling the container images from your private container registry.
+
    ```console
    kubectl create secret docker-registry reg-acr-secrets \
      --docker-server=<your private container registry login server> \
@@ -164,6 +184,7 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
    Also, you need to specify the `reg-acr-secrets` as the value of `[].imagePullSecrets`.
    * ScalarDB Examples
       * ScalarDB Server (scalardb-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -181,7 +202,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDB GraphQL Server (scalardb-graphql-custom-values.yaml)
+
         ```yaml
         image:
           repository: "example.azurecr.io/scalarinc/scalardb-graphql"
@@ -189,8 +212,10 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
         imagePullSecrets:
           - name: "reg-acr-secrets"
         ```
+
    * ScalarDL Examples
       * ScalarDL Ledger (scalardl-ledger-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -208,7 +233,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Auditor (scalardl-auditor-custom-values.yaml)
+
         ```yaml
         envoy:
           image:
@@ -226,7 +253,9 @@ Please refer to the [Azure Container Registry documentation](https://docs.micros
           imagePullSecrets:
             - name: "reg-acr-secrets"
         ```
+
       * ScalarDL Schema Loader (schema-loader-custom-values.yaml)
+      
         ```yaml
         schemaLoading:
           image:

--- a/docs/latest/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/latest/scalar-kubernetes/BackupNoSQL.md
@@ -43,14 +43,19 @@ If you use Scalar Helm Charts to deploy ScalarDB or ScalarDL, the `my-svc` and `
 
 * Example
   * ScalarDB Server
+
     ```console
     _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -90,14 +95,19 @@ You can send a pause request to ScalarDB or ScalarDL pods in a Kubernetes enviro
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-pause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c pause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -108,14 +118,19 @@ You can send an unpause request to ScalarDB or ScalarDL pods in a Kubernetes env
 
 * Example
   * ScalarDB Server
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardb._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Ledger
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
+
   * ScalarDL Auditor
+
     ```console
     kubectl run scalar-admin-unpause --image=ghcr.io/scalar-labs/scalar-admin:<tag> --restart=Never -it -- -c unpause -s _scalardl-auditor-admin._tcp.<helm release name>-headless.<namespace>.svc.cluster.local
     ```
@@ -127,6 +142,7 @@ The `scalar-admin` pods output the `pause completed` time and `unpause started` 
 ```console
 kubectl logs scalar-admin-pause
 ```
+
 ```console
 kubectl logs scalar-admin-unpause
 ```

--- a/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -96,6 +96,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -103,6 +104,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -132,6 +134,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -139,6 +142,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -99,6 +99,7 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -106,6 +107,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this label in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -135,6 +137,7 @@ In addition, you can set this label in the Azure portal or use the `--labels` fl
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -142,6 +145,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, you can set this taint in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/latest/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -117,10 +117,13 @@ Note that you also must allow the connections that AKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -128,6 +131,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these labels in the Azure portal or use the `--labels` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these labels to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -151,7 +155,9 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -181,10 +187,13 @@ In addition, you can set these labels in the Azure portal or use the `--labels` 
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -192,6 +201,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, you can set these taints in the Azure portal or use the `--node-taints` flag of the [az aks nodepool add](https://learn.microsoft.com/en-us/cli/azure/aks/nodepool?view=azure-cli-latest#az-aks-nodepool-add) command when you create a node pool. If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -207,7 +217,9 @@ In addition, you can set these taints in the Azure portal or use the `--node-tai
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/latest/scalar-kubernetes/CreateBastionServer.md
@@ -26,15 +26,19 @@ If you use AKS (Azure Kubernetes Service), you must install the **Azure CLI** ac
 You can check if the tools are installed as follows.
 
 * kubectl
+
   ```console
   kubectl version --client
   ```
+
 * helm
+
   ```console
   helm version
   ```
 
 You can also check if your kubeconfig is properly configured as follows. If you see a URL response, kubectl is correctly configured to access your cluster.
+
 ```console
 kubectl cluster-info
 ```

--- a/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,4 +1,6 @@
-# Guidelines for creating an EKS cluster for ScalarDB Server
+# (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
+
+**Note:** ScalarDB Server is now deprecated. Please use [ScalarDB Cluster](./ManualDeploymentGuideScalarDBClusterOnEKS.md) instead.
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an EKS cluster, see [Deploy ScalarDB Server on Amazon EKS](./ManualDeploymentGuideScalarDBServerOnEKS.md).
 
@@ -76,6 +78,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb
   ```
@@ -83,6 +86,7 @@ You can make a specific worker node dedicated to ScalarDB Server by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDB Server, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     affinity:
@@ -112,6 +116,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDB Server by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDB Server pods (e.g., application pods) on the worker node for ScalarDB Server. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDB Server example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardb:NoSchedule
   ```
@@ -121,6 +126,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDB Server, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDB Server example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -79,6 +79,7 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
@@ -86,6 +87,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger by using **node
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -115,6 +117,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger pods (e.g., application pods) on the worker node for ScalarDL Ledger. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
@@ -124,6 +127,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add this taint to make specific worker nodes dedicated to ScalarDL Ledger, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -96,10 +96,13 @@ Note that you also must allow the connections that EKS uses itself. For more det
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add a label to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl label node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor
   ```
@@ -107,6 +110,7 @@ You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Aud
 In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/create-managed-node-group.html) in EKS, you can set this label when you create a managed node group. If you add this label to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **nodeAffinity** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     affinity:
@@ -130,7 +134,9 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
                   values:
                     - scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     affinity:
@@ -160,10 +166,13 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 You can make a specific worker node dedicated to ScalarDL Ledger or ScalarDL Auditor by using **nodeAffinity** and **taint/toleration**, which are Kubernetes features. In other words, you can avoid deploying non-ScalarDL Ledger and non-ScalarDL Auditor pods (e.g., application pods) on the worker node for ScalarDL Ledger and ScalarDL Auditor. To add taint to the worker node, you can use the `kubectl` command as follows.
 
 * ScalarDL Ledger example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-ledger:NoSchedule
   ```
+
 * ScalarDL Auditor example
+
   ```console
   kubectl taint node <WORKER_NODE_NAME> scalar-labs.com/dedicated-node=scalardl-auditor:NoSchedule
   ```
@@ -173,6 +182,7 @@ In addition, if you use [managed node groups](https://docs.aws.amazon.com/eks/la
 If you add these taints to make specific worker nodes dedicated to ScalarDL Ledger and ScalarDL Auditor, you must configure **tolerations** in your custom values file as follows.
 
 * ScalarDL Ledger example
+
   ```yaml
   envoy:
     tolerations:
@@ -188,7 +198,9 @@ If you add these taints to make specific worker nodes dedicated to ScalarDL Ledg
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor example
+
   ```yaml
   envoy:
     tolerations:

--- a/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/latest/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -2,7 +2,8 @@
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:
 
-* [Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
+* [Guidelines for creating an EKS cluster for ScalarDB Cluster](./CreateEKSClusterForScalarDBCluster.md)
+* [(Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server](./CreateEKSClusterForScalarDB.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger](./CreateEKSClusterForScalarDL.md)
 * [Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor](./CreateEKSClusterForScalarDLAuditor.md)
 

--- a/docs/latest/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/latest/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -24,6 +24,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add grafana https://grafana.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,19 +42,32 @@ In the production environment, it is recommended to add labels to the worker nod
 
 Since the promtail pods deployed in this document collect only Scalar product logs, it is sufficient to deploy promtail pods only on the worker node where Scalar products are running. So, you should set nodeSelector in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add labels to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    nodeSelector:
+      scalar-labs.com/dedicated-node: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     nodeSelector:
       scalar-labs.com/dedicated-node: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     nodeSelector:
@@ -69,7 +83,19 @@ In the production environment, it is recommended to add taints to the worker nod
 
 Since promtail pods are deployed as DaemonSet, you must set tolerations in the custom values file (scalar-loki-stack-custom-values.yaml) as follows if you add taints to your Kubernetes worker node.
 
-* ScalarDB Example
+* ScalarDB Cluster Example
+
+  ```yaml
+  promtail:
+    tolerations:
+      - effect: NoSchedule
+        key: scalar-labs.com/dedicated-node
+        operator: Equal
+        value: scalardb-cluster
+  ```
+
+* (Deprecated) ScalarDB Server Example
+
   ```yaml
   promtail:
     tolerations:
@@ -78,7 +104,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardb
   ```
+
 * ScalarDL Ledger Example
+
   ```yaml
   promtail:
     tolerations:
@@ -87,7 +115,9 @@ Since promtail pods are deployed as DaemonSet, you must set tolerations in the c
         operator: Equal
         value: scalardl-ledger
   ```
+
 * ScalarDL Auditor Example
+
   ```yaml
   promtail:
     tolerations:

--- a/docs/latest/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/latest/scalar-kubernetes/K8sMonitorGuide.md
@@ -22,6 +22,7 @@ This document uses Helm for the deployment of Prometheus Operator.
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
+
 ```console
 helm repo update
 ```
@@ -41,11 +42,13 @@ Please refer to the following official document for more details on the configur
 Scalar products assume the Prometheus Operator is deployed in the `monitoring` namespace by default. So, please create the namespace `monitoring` and deploy Prometheus Operator in the `monitoring` namespace.
 
 1. Create a namespace `monitoring` on Kubernetes.
+
    ```console
    kubectl create namespace monitoring
    ```
 
 1. Deploy the kube-prometheus-stack.
+
    ```console
    helm install scalar-monitoring prometheus-community/kube-prometheus-stack -n monitoring -f scalar-prometheus-custom-values.yaml
    ```
@@ -74,17 +77,19 @@ scalar-monitoring-kube-pro-operator-865bbb8454-9ppkc     1/1     Running   0    
 
    Please refer to the following documents for more details on the custom values file of each Scalar product.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations)
-   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations)
-   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-cluster.md#prometheus-and-grafana-configurations--recommended-in-production-environments)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb.md#prometheusgrafana-configurations--recommended-in-the-production-environment)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardb-graphql.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-ledger.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
+   * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-auditor.md#prometheusgrafana-configurations-recommended-in-the-production-environment)
 
 1. Deploy (or Upgrade) Scalar products using Helm Charts with the above custom values file.
 
    Please refer to the following documents for more details on how to deploy/upgrade Scalar products.
 
-   * [ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
-   * [ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
+   * [ScalarDB Cluster](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-cluster.md)
+   * [(Deprecated) ScalarDB Server](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb.md)
+   * [(Deprecated) ScalarDB GraphQL](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardb-graphql.md)
    * [ScalarDL Ledger](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-ledger.md)
    * [ScalarDL Auditor](https://github.com/scalar-labs/helm-charts/blob/main/docs/how-to-deploy-scalardl-auditor.md)
 
@@ -105,38 +110,52 @@ You can access each dashboard from your local machine using the `kubectl port-fo
 
 1. Port forwarding to each service from your local machine.
    * Prometheus
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-prometheus 9090:9090
      ```
+
    * Alertmanager
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-kube-pro-alertmanager 9093:9093
      ```
+
    * Grafana
+
      ```console
      kubectl port-forward -n monitoring svc/scalar-monitoring-grafana 3000:3000
      ```
 
 1. Access each Dashboard.
    * Prometheus
+
      ```console
      http://localhost:9090/
      ```
+
    * Alertmanager
+
      ```console
      http://localhost:9093/
      ```
+
    * Grafana
+
      ```console
      http://localhost:3000/
      ```
+
        * Note:
            * You can see the user and password of Grafana as follows.
                * user
+
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-user}' | base64 -d
                  ```
+
                * password
+               
                  ```console
                  kubectl get secrets scalar-monitoring-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 -d
                  ```

--- a/docs/latest/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/latest/scalar-kubernetes/RestoreDatabase.md
@@ -6,17 +6,23 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
 
 1. Scale in ScalarDB or ScalarDL pods to **0** to stop requests to the backend databases. You can scale in the pods to **0** by using the `--set *.replicaCount=0` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=0
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=0
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=0
      ```
+
 2. Restore the databases by using the point-in-time recovery (PITR) feature. 
 
    For details on how to restore the databases based on your managed database, please refer to the [Supplemental procedures to restore databases based on managed database](./RestoreDatabase.md#supplemental-procedures-to-restore-databases-based-on-managed-database) section in this guide.
@@ -29,14 +35,19 @@ This guide explains how to restore databases that ScalarDB or ScalarDL uses in a
    Please note that, if you are using Amazon DynamoDB, your data will be restored with another table name instead of another instance. In other words, the endpoint will not change after restoring the data. Instead, you will need to restore the data by renaming the tables in Amazon DynamoDB. For details on how to restore data with the same table name, please see the [Amazon DynamoDB](./RestoreDatabase.md#amazon-dynamodb) section in this guide.
 4. Scale out the ScalarDB or ScalarDL pods to **1** or more to start accepting requests from clients by using the `--set *.replicaCount=N` flag in the helm command.
    * ScalarDB Server
+
      ```console
      helm upgrade <release name> scalar-labs/scalardb -n <namespace> -f /path/to/<your custom values file for ScalarDB Server> --set scalardb.replicaCount=3
      ```
+
    * ScalarDL Ledger
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl -n <namespace> -f /path/to/<your custom values file for ScalarDL Ledger> --set ledger.replicaCount=3
      ```
+
    * ScalarDL Auditor
+
      ```console
      helm upgrade <release name> scalar-labs/scalardl-audit -n <namespace> -f /path/to/<your custom values file for ScalarDL Auditor> --set auditor.replicaCount=3
      ```
@@ -87,21 +98,26 @@ When using the PITR feature, Azure Cosmos DB restores data by using another acco
 3. Update **database.properties** for ScalarDB Schema Loader or ScalarDL Schema Loader based on the newly restored account.
 
    ScalarDB implements the Cosmos DB adapter by using its stored procedures, which are installed when creating schemas by using ScalarDB Schema Loader or ScalarDL Schema Loader. However, the PITR feature in Cosmos DB does not restore stored procedures, so you will need to reinstall the required stored procedures for all tables after restoration. You can reinstall the required stored procedures by using the `--repair-all` option in ScalarDB Schema Loader or ScalarDL Schema Loader.
-   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Getting Started with ScalarDB on Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md).
+   * **ScalarDB tables:** For details on how to configure **database.properties** for ScalarDB Schema Loader, see [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1).
 
    * **ScalarDL tables:** For details on how to configure the custom values file for ScalarDL Schema Loader, see [Configure a custom values file for ScalarDL Schema Loader](https://github.com/scalar-labs/helm-charts/blob/main/docs/configure-custom-values-scalardl-schema-loader.md).
 
 4. Re-create the stored procedures by using the `--repair-all` flag in ScalarDB Schema Loader or ScalarDL Schema Loader as follows:
 
    * ScalarDB tables
+
      ```console
      java -jar scalardb-schema-loader-<version>.jar --config /path/to/<your database.properties> -f /path/to/<your schema.json file> [--coordinator] --repair-all 
      ```
+
    * ScalarDL Ledger tables
+
      ```console
      helm install repair-schema-ledger scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Ledger> --set "schemaLoading.commandArgs={--repair-all}"
      ```
+
    * ScalarDL Auditor tables
+   
      ```console
      helm install repair-schema-auditor scalar-labs/schema-loading -n <namespace> -f /path/to/<your custom values file for ScalarDL Schema Loader for Auditor> --set "schemaLoading.commandArgs={--repair-all}"
      ```

--- a/docs/latest/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/latest/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -17,7 +17,7 @@ scalar.db.storage=dynamo
 
 Please refer to the following document for more details on the properties for DynamoDB.
 
-* [Getting Started with ScalarDB on DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-dynamodb.md)
+* [Configure ScalarDB for DynamoDB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-2)
 
 ### Required configuration/steps
 
@@ -77,7 +77,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for RDS (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -132,7 +132,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Amazon Aurora (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 

--- a/docs/latest/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/latest/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -16,7 +16,7 @@ scalar.db.storage=cosmos
 
 Please refer to the following document for more details on the properties for Cosmos DB for NoSQL.
 
-* [Getting Started with ScalarDB on Cosmos DB](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-cosmosdb.md)
+* [Configure ScalarDB for Cosmos DB for NoSQL](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-1)
 
 ### Required configuration/steps
 
@@ -85,7 +85,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for MySQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 
@@ -149,7 +149,7 @@ scalar.db.storage=jdbc
 
 Please refer to the following document for more details on the properties for Azure Database for PostgreSQL (JDBC databases).
 
-* [Getting Started with ScalarDB on JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb-on-jdbc.md)
+* [Configure ScalarDB for JDBC databases](https://github.com/scalar-labs/scalardb/blob/master/docs/getting-started-with-scalardb.md#configure-scalardb-3)
 
 ### Required configuration/steps
 


### PR DESCRIPTION
## Description

This PR adds updated docs for Scalar Kubernetes and fixes code block formatting in Scalar Helm Charts docs. Some code blocks, particularly those that contain hyphens (rendered as a bulleted item in Jekyll) and are nested in bulleted lists, don't appear as expected.

### Related issue or PR

N/A

### Type of change

- [X] Documentation (new or updated documentation)
- [ ] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and confirmed that the updated docs and broken code blocks appeared as expected.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.
