### PR TITLE
Change the size of the Copy button

### DIFF
--- a/_sass/minimal-mistakes/_syntax.scss
+++ b/_sass/minimal-mistakes/_syntax.scss
@@ -23,13 +23,12 @@ figure.highlight {
   /* The following button style is for the copy button that allows users to copy content in a code block to a clipboard. (added by josh-wong) */
   pre.highlight > button {
     background-color: $scalar-primary-color;
-    border: none;
+    border: $scalar-primary-color 1px solid;
     color: $lighter-gray;
     display: block;
     font-family: $sans-serif;
     font-size: $type-size-4-5;
-    height: 100%;
-    line-height: 1.5;
+    line-height: 1.85;
     min-width: 8.5%;
     outline: none;
     padding: 0.7em;
@@ -42,6 +41,7 @@ figure.highlight {
     &:focus,
     &:hover {
       background-color: darken($scalar-primary-color, 15%);
+      border: darken($scalar-primary-color, 15%) 1px solid;
       outline: none;
     }
   }


### PR DESCRIPTION
## Description

This PR makes the **Copy** button smaller so that it doesn't extend 100% the height of the code block.

### Related issue or PR

https://github.com/scalar-labs/docs-scalardl/pull/34

### Type of change

- [ ] Documentation (new or updated documentation)
- [x] Improvement (an improvement to the existing state)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Bug fix (nonbreaking change that fixes an issue)

## How has this been tested?

- [x] Ran `bundle exec jekyll serve` to deploy this docs site locally on my machine. Accessed the site locally, cleared my browser cache, and navigated to multiple pages that have code blocks. On those pages, I confirmed that the **Copy** button in the code block appeared smaller.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have conducted tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.