### PR TITLE
Add `{% raw %}` and `{% endraw %}` to code blocks that contain Liquid syntax

### DIFF
--- a/docs/3.5/helm-charts/getting-started-scalardb.md
+++ b/docs/3.5/helm-charts/getting-started-scalardb.md
@@ -105,6 +105,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -128,9 +129,11 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -154,6 +157,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
         EOF
      ```
+     {% endraw %}
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
 

--- a/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-auditor.md
@@ -284,6 +284,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -301,9 +302,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -321,10 +324,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -342,9 +347,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -362,6 +369,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
 
@@ -414,6 +422,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,9 +457,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -484,10 +495,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -522,9 +535,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -559,6 +574,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.5/helm-charts/getting-started-scalardl-ledger.md
@@ -223,6 +223,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,8 +241,10 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -259,6 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
 
@@ -295,6 +299,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -328,9 +333,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -364,6 +371,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.5/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.5/helm-charts/use-secret-for-credentials.md
@@ -33,6 +33,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
 
+             {% raw %}
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -41,6 +42,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+             {% endraw %}
 
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
 
@@ -66,6 +68,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
        * ScalarDL Ledger (Go template syntax)
 
+          {% raw %}
           ```yaml
           ledger:
             ledgerProperties: |
@@ -74,9 +77,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+          {% endraw %}
 
        * ScalarDL Auditor (Go template syntax)
 
+         {% raw %}
          ```yaml
          auditor:
            auditorProperties: |
@@ -85,9 +90,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
        * ScalarDL Schema Loader (Go template syntax)
 
+         {% raw %}
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -96,6 +103,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
@@ -157,6 +165,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * Custom values file
 
+         {% raw %}
          ```yaml
          scalardb:
            databaseProperties: |
@@ -165,6 +174,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+         {% endraw %}
 
        * Properties file in containers
        

--- a/docs/3.6/helm-charts/getting-started-scalardb.md
+++ b/docs/3.6/helm-charts/getting-started-scalardb.md
@@ -105,6 +105,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -128,9 +129,11 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -154,6 +157,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
         EOF
      ```
+     {% endraw %}
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
 

--- a/docs/3.6/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.6/helm-charts/getting-started-scalardl-auditor.md
@@ -284,6 +284,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -301,9 +302,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -321,10 +324,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -342,9 +347,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -362,6 +369,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
 
@@ -414,6 +422,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,9 +457,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -484,10 +495,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -522,9 +535,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -559,6 +574,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.6/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.6/helm-charts/getting-started-scalardl-ledger.md
@@ -223,6 +223,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,8 +241,10 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -259,6 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
 
@@ -295,6 +299,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -328,9 +333,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -364,6 +371,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.6/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.6/helm-charts/use-secret-for-credentials.md
@@ -33,6 +33,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
 
+             {% raw %}
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -41,6 +42,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+             {% endraw %}
 
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
 
@@ -66,6 +68,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
        * ScalarDL Ledger (Go template syntax)
 
+          {% raw %}
           ```yaml
           ledger:
             ledgerProperties: |
@@ -74,9 +77,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+          {% endraw %}
 
        * ScalarDL Auditor (Go template syntax)
 
+         {% raw %}
          ```yaml
          auditor:
            auditorProperties: |
@@ -85,9 +90,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
        * ScalarDL Schema Loader (Go template syntax)
 
+         {% raw %}
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -96,6 +103,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
@@ -157,6 +165,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * Custom values file
 
+         {% raw %}
          ```yaml
          scalardb:
            databaseProperties: |
@@ -165,6 +174,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+         {% endraw %}
 
        * Properties file in containers
        

--- a/docs/3.7/helm-charts/getting-started-scalardb.md
+++ b/docs/3.7/helm-charts/getting-started-scalardb.md
@@ -105,6 +105,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -128,9 +129,11 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -154,6 +157,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
         EOF
      ```
+     {% endraw %}
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
 

--- a/docs/3.7/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.7/helm-charts/getting-started-scalardl-auditor.md
@@ -284,6 +284,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -301,9 +302,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -321,10 +324,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -342,9 +347,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -362,6 +369,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
 
@@ -414,6 +422,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,9 +457,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -484,10 +495,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -522,9 +535,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -559,6 +574,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.7/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.7/helm-charts/getting-started-scalardl-ledger.md
@@ -223,6 +223,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,8 +241,10 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -259,6 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
 
@@ -295,6 +299,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -328,9 +333,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -364,6 +371,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.7/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.7/helm-charts/use-secret-for-credentials.md
@@ -33,6 +33,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
 
+             {% raw %}
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -41,6 +42,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+             {% endraw %}
 
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
 
@@ -66,6 +68,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
        * ScalarDL Ledger (Go template syntax)
 
+          {% raw %}
           ```yaml
           ledger:
             ledgerProperties: |
@@ -74,9 +77,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+          {% endraw %}
 
        * ScalarDL Auditor (Go template syntax)
 
+         {% raw %}
          ```yaml
          auditor:
            auditorProperties: |
@@ -85,9 +90,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
        * ScalarDL Schema Loader (Go template syntax)
 
+         {% raw %}
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -96,6 +103,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
@@ -157,6 +165,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * Custom values file
 
+         {% raw %}
          ```yaml
          scalardb:
            databaseProperties: |
@@ -165,6 +174,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+         {% endraw %}
 
        * Properties file in containers
        

--- a/docs/3.8/helm-charts/getting-started-scalardb.md
+++ b/docs/3.8/helm-charts/getting-started-scalardb.md
@@ -105,6 +105,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -128,9 +129,11 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -154,6 +157,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
         EOF
      ```
+     {% endraw %}
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
 

--- a/docs/3.8/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.8/helm-charts/getting-started-scalardl-auditor.md
@@ -284,6 +284,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -301,9 +302,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -321,10 +324,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -342,9 +347,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -362,6 +369,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
 
@@ -414,6 +422,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,9 +457,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -484,10 +495,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -522,9 +535,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -559,6 +574,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.8/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.8/helm-charts/getting-started-scalardl-ledger.md
@@ -223,6 +223,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,8 +241,10 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -259,6 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
 
@@ -295,6 +299,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -328,9 +333,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -364,6 +371,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/3.8/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.8/helm-charts/use-secret-for-credentials.md
@@ -33,6 +33,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
 
+             {% raw %}
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -41,6 +42,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+             {% endraw %}
 
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
 
@@ -66,6 +68,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
        * ScalarDL Ledger (Go template syntax)
 
+          {% raw %}
           ```yaml
           ledger:
             ledgerProperties: |
@@ -74,9 +77,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+          {% endraw %}
 
        * ScalarDL Auditor (Go template syntax)
 
+         {% raw %}
          ```yaml
          auditor:
            auditorProperties: |
@@ -85,9 +90,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
        * ScalarDL Schema Loader (Go template syntax)
 
+         {% raw %}
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -96,6 +103,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
@@ -157,6 +165,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * Custom values file
 
+         {% raw %}
          ```yaml
          scalardb:
            databaseProperties: |
@@ -165,6 +174,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+         {% endraw %}
 
        * Properties file in containers
        

--- a/docs/latest/helm-charts/getting-started-scalardb.md
+++ b/docs/latest/helm-charts/getting-started-scalardb.md
@@ -105,6 +105,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
 1. Create a custom values file for ScalarDB Server (scalardb-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -128,9 +129,11 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > scalardb-custom-values.yaml
      envoy:
@@ -154,6 +157,7 @@ You can deploy PostgreSQL on the Kubernetes cluster as follows.
        secretName: "scalardb-credentials-secret"
         EOF
      ```
+     {% endraw %}
 
 1. Create a Secret resource that includes a username and password for PostgreSQL.
 

--- a/docs/latest/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/latest/helm-charts/getting-started-scalardl-auditor.md
@@ -284,6 +284,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Schema Loader for Ledger (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -301,9 +302,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -321,10 +324,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Schema Loader for Auditor (schema-loader-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -342,9 +347,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-auditor-custom-values.yaml
      schemaLoading:
@@ -362,6 +369,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
        secretName: "auditor-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL for Ledger.
 
@@ -414,6 +422,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -448,9 +457,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -484,10 +495,12 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create a custom values file for ScalarDL Auditor (scalardl-auditor-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -522,9 +535,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-auditor-custom-values.yaml
      envoy:
@@ -559,6 +574,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger and Au
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/latest/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/latest/helm-charts/getting-started-scalardl-ledger.md
@@ -223,6 +223,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Schema Loader (schema-loader-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -240,8 +241,10 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/schema-loader-ledger-custom-values.yaml
      schemaLoading:
@@ -259,6 +262,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
        secretName: "ledger-credentials-secret"
      EOF
      ```
+     {% endraw %}
 
 1. Create a secret resource that includes a username and password for PostgreSQL.
 
@@ -295,6 +299,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
 1. Create a custom values file for ScalarDL Ledger (scalardl-ledger-custom-values.yaml).
    * AWS Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -328,9 +333,11 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
    * Azure Marketplace
 
+     {% raw %}
      ```console
      cat << 'EOF' > ~/scalardl-test/scalardl-ledger-custom-values.yaml
      envoy:
@@ -364,6 +371,7 @@ The ScalarDL Schema Loader will create the DB schemas for ScalarDL Ledger in Pos
            readOnly: true
      EOF
      ```
+     {% endraw %}
 
 1. Create secret resource `ledger-keys`.
 

--- a/docs/latest/helm-charts/use-secret-for-credentials.md
+++ b/docs/latest/helm-charts/use-secret-for-credentials.md
@@ -33,6 +33,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
        * ScalarDB Server
            * ScalarDB Server 3.7 or earlier (Go template syntax)
 
+             {% raw %}
              ```yaml
              scalardb:
                 databaseProperties: |
@@ -41,6 +42,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
                   scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
                   ...
              ```
+             {% endraw %}
 
            * ScalarDB Server 3.8 or later (Apache Commons Text syntax)
 
@@ -66,6 +68,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
 
        * ScalarDL Ledger (Go template syntax)
 
+          {% raw %}
           ```yaml
           ledger:
             ledgerProperties: |
@@ -74,9 +77,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
               scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
               ...
           ```
+          {% endraw %}
 
        * ScalarDL Auditor (Go template syntax)
 
+         {% raw %}
          ```yaml
          auditor:
            auditorProperties: |
@@ -85,9 +90,11 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
        * ScalarDL Schema Loader (Go template syntax)
 
+         {% raw %}
          ```yaml
          schemaLoading:
            databaseProperties: |
@@ -96,6 +103,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              ...
          ```
+         {% endraw %}
 
 1. Create a `Secret` resource that includes credentials.  
    You need to specify the environment variable name as keys of the `Secret`.
@@ -157,6 +165,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
    * Example
        * Custom values file
 
+         {% raw %}
          ```yaml
          scalardb:
            databaseProperties: |
@@ -165,6 +174,7 @@ SCALAR_DB_CLUSTER_MEMBERSHIP_KUBERNETES_ENDPOINT_NAME
              scalar.db.password={{ default .Env.SCALAR_DB_PASSWORD "" }}
              scalar.db.storage=jdbc
          ```
+         {% endraw %}
 
        * Properties file in containers
        


### PR DESCRIPTION
## Description

This PR adds `{% raw %}` and `{% endraw %}` to code blocks that contain Liquid syntax.

In Jekyll-based static site generators, `{{ ... }}` characters are used for Liquid syntax, which causes content to not be displayed, even in code blocks. By enclosing Markdown with `{% raw %}` and `{% endraw %}`, Jekyll will show the text as it should appear, ignoring any possible Liquid syntax.

## Related issues and/or PRs

N/A

## Changes made

- Added `{% raw %}` before the start of code blocks and `{% endraw %}` to the end of code blocks that contain Liquid (`{{ ... }}`) syntax.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
