### PR TITLE
Remove irrelevant doc from side navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -90,8 +90,6 @@ versions:
   # Deploy docs
   - title: "Deploy"
     children:
-      - title: "ScalarDL Deployment Sample on Kubernetes (Auditor mode)"
-        url: /docs/latest/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README/
       - title: "Deploying ScalarDL on Managed Kubernetes Services"
         url: /docs/latest/scalar-kubernetes/deploy-kubernetes/
       - title: "How to install ScalarDL in your local environment with Docker"
@@ -200,8 +198,6 @@ versions:
   # Deploy docs
   - title: "Deploy"
     children:
-      - title: "ScalarDL Deployment Sample on Kubernetes (Auditor mode)"
-        url: /docs/3.7/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README/
       - title: "Deploying ScalarDL on Managed Kubernetes Services"
         url: /docs/3.7/scalar-kubernetes/deploy-kubernetes/
       - title: "How to install ScalarDL in your local environment with Docker"
@@ -310,8 +306,6 @@ versions:
   # Deploy docs
   - title: "Deploy"
     children:
-      - title: "ScalarDL Deployment Sample on Kubernetes (Auditor mode)"
-        url: /docs/3.6/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README/
       - title: "Deploying ScalarDL on Managed Kubernetes Services"
         url: /docs/3.6/scalar-kubernetes/deploy-kubernetes/
       - title: "How to install ScalarDL in your local environment with Docker"
@@ -420,8 +414,6 @@ versions:
   # Deploy docs
   - title: "Deploy"
     children:
-      - title: "ScalarDL Deployment Sample on Kubernetes (Auditor mode)"
-        url: /docs/3.5/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README/
       - title: "Deploying ScalarDL on Managed Kubernetes Services"
         url: /docs/3.5/scalar-kubernetes/deploy-kubernetes/
       - title: "How to install ScalarDL in your local environment with Docker"
@@ -530,8 +522,6 @@ versions:
   # Deploy docs
   - title: "Deploy"
     children:
-      - title: "ScalarDL Deployment Sample on Kubernetes (Auditor mode)"
-        url: /docs/3.4/helm-charts/samples/scalardl/scalardl-auditor-mode-sample/README/
       - title: "Deploying ScalarDL on Managed Kubernetes Services"
         url: /docs/3.4/scalar-kubernetes/deploy-kubernetes/
       - title: "How to install ScalarDL in your local environment with Docker"


### PR DESCRIPTION
## Description

This PR removes a link to an irrelevant doc, which was recently removed, from the side navigation.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardl/pull/63

## Changes made

- Removed a doc, which was removed in the related PR, from the side navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A