### PR TITLE
Add unsupported versions page; update version dropdown menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -275,6 +275,20 @@ defaults:
       toc_sticky: true
       search: true
 
+  # Common docs in the `docs` root folder
+  - scope:
+      path: "docs" # Specifies the name of the folder where the common docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
+
   # Hides ScalarDB-related pages (e.g., Helm Charts docs) from search results.
   # NOTE: The following method causes a lengthy build time, which occasionally causes the build to remain "In progress" indefinitely. Because of that, it is currently commented out until we find an alternative way to hide specific pages from search results.
   # - scope:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,8 +36,9 @@ versions:
       version-url: /docs/3.6
     - version-title: "3.5"
       version-url: /docs/3.5
-    - version-title: "3.4"
-      version-url: /docs/3.4
+    # The following link contains a list of versions of ScalarDB that are no longer supported.
+    - version-title: "Unsupported Versions"
+      version-url: /docs/unsupported-versions/
 
 # ----- Adding navigation for versions ----- #
 

--- a/docs/unsupported-versions.md
+++ b/docs/unsupported-versions.md
@@ -5,3 +5,5 @@ toc: false
 # Unsupported Versions
 
 The following versions of ScalarDL are no longer supported:
+
+- [ScalarDL 3.4](3.4/getting-started.md)

--- a/docs/unsupported-versions.md
+++ b/docs/unsupported-versions.md
@@ -1,0 +1,7 @@
+---
+toc: false
+---
+
+# Unsupported Versions
+
+The following versions of ScalarDL are no longer supported:


### PR DESCRIPTION
> [!WARNING]
>
> This PR can be merged on January 30, 2024, when Assistance Support for ScalarDL 3.4 ends.

## Description

This PR adds an unsupported versions page to reduce, what will eventually and naturally be, a growing list of versions of docs that are out of support. In addition, a link to that page has been added to the version dropdown menu.

## Related issues and/or PRs

N/A

## Changes made

- Add a page that lists the currently unsupported versions to the `docs` folder.
- Replace the unsupported versions in the version dropdown navigation with a link to the page that lists the unsupported versions.
- Add a scope to the theme configuration so that the static site generator displays that unsupported versions page since it's in the `docs` folder, which previously didn't have any docs in that folder.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
