### PR TITLE
Add out-of-support banner to docs to show that ScalarDL 3.4 is no longer supported

### DIFF
--- a/docs/3.4/applications/escrow-payment/README.md
+++ b/docs/3.4/applications/escrow-payment/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Escrow payment CLI
 
 The following is a simple Java CLI application to try out and test [ScalarDL](https://github.com/scalar-labs/scalardl). PicoCLI is used as a CLI framework.

--- a/docs/3.4/applications/simple-bank-account/README.md
+++ b/docs/3.4/applications/simple-bank-account/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A simple bank account application
 
 ## Overview

--- a/docs/3.4/applications/simple-bank-account/docs/api_endpoints.md
+++ b/docs/3.4/applications/simple-bank-account/docs/api_endpoints.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # API endpoints
 
 ## `GET v1/accounts`

--- a/docs/3.4/authentication.md
+++ b/docs/3.4/authentication.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Authentication Guide
 
 This document explains the ScalarDL authentication mechanism and how to use it properly. 

--- a/docs/3.4/backup-restore.md
+++ b/docs/3.4/backup-restore.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A Guide on How to Backup and Restore Data in ScalarDL
 
 Since ScalarDL uses ScalarDB that provides transaction capability on top of non-transactional (possibly transactional) databases non-invasively,

--- a/docs/3.4/ca/caclient-getting-started.md
+++ b/docs/3.4/ca/caclient-getting-started.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to get a certificate
 
 This document describes how to get a certificate to enroll in ScalarDL network.

--- a/docs/3.4/ca/caserver-getting-started.md
+++ b/docs/3.4/ca/caserver-getting-started.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to start CA sever with CFSSL
 
 This document describes how to start CA server with CFSSL.

--- a/docs/3.4/compatibility.md
+++ b/docs/3.4/compatibility.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Compatibility Matrix
 
 This document shows ScalarDL Ledger and Auditor compatibility with the ScalarDL Java Client SDK.

--- a/docs/3.4/design.md
+++ b/docs/3.4/design.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Design Document
 
 For details about the design and implementation of ScalarDL, please see the following documents, which we presented at the VLDB 2022 conference:

--- a/docs/3.4/getting-started-auditor.md
+++ b/docs/3.4/getting-started-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with ScalarDL Auditor
 
 This document explains how to get started with ScalarDL Auditor.

--- a/docs/3.4/getting-started.md
+++ b/docs/3.4/getting-started.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with ScalarDL
 
 This document explains how to get started with ScalarDL by running your first simple contract using the Client SDK.

--- a/docs/3.4/helm-charts/README.md
+++ b/docs/3.4/helm-charts/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Index
 
 ## For users

--- a/docs/3.4/helm-charts/configure-custom-values-envoy.md
+++ b/docs/3.4/helm-charts/configure-custom-values-envoy.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for Scalar Envoy
 
 This document explains how to create your custom values file for the Scalar Envoy chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/envoy/README.md) of the Scalar Envoy chart.

--- a/docs/3.4/helm-charts/configure-custom-values-file.md
+++ b/docs/3.4/helm-charts/configure-custom-values-file.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for Scalar Helm Charts
 
 When you deploy Scalar products using Scalar Helm Charts, you must prepare your custom values file based on your environment. Please refer to the following documents for more details on how to a create custom values file for each product.

--- a/docs/3.4/helm-charts/configure-custom-values-scalar-manager.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for Scalar Manager
 
 This document explains how to create your custom values file for the Scalar Manager chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalar-manager/README.md) of the Scalar Manager chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb-cluster.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for ScalarDB Cluster
 
 This document explains how to create your custom values file for the ScalarDB Cluster chart. For details on the parameters, see the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardb-cluster/README.md) of the ScalarDB Cluster chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb-graphql.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # [Deprecated] Configure a custom values file for ScalarDB GraphQL
 
 {% capture notice--info %}

--- a/docs/3.4/helm-charts/configure-custom-values-scalardb.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # [Deprecated] Configure a custom values file for ScalarDB Server
 
 {% capture notice--info %}

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Auditor
 
 This document explains how to create your custom values file for the ScalarDL Auditor chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl-audit/README.md) of the ScalarDL Auditor chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Ledger
 
 This document explains how to create your custom values file for the ScalarDL Ledger chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/scalardl/README.md) of the ScalarDL Ledger chart.

--- a/docs/3.4/helm-charts/configure-custom-values-scalardl-schema-loader.md
+++ b/docs/3.4/helm-charts/configure-custom-values-scalardl-schema-loader.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure a custom values file for ScalarDL Schema Loader
 
 This document explains how to create your custom values file for the ScalarDL Schema Loader chart. If you want to know the details of the parameters, please refer to the [README](https://github.com/scalar-labs/helm-charts/blob/main/charts/schema-loading/README.md) of the ScalarDL Schema Loader chart.

--- a/docs/3.4/helm-charts/getting-started-logging.md
+++ b/docs/3.4/helm-charts/getting-started-logging.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Helm Charts (Logging using Loki Stack)
 
 This document explains how to get started with log aggregation for Scalar products on Kubernetes using Grafana Loki (with Promtail).

--- a/docs/3.4/helm-charts/getting-started-monitoring.md
+++ b/docs/3.4/helm-charts/getting-started-monitoring.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Helm Charts (Monitoring using Prometheus Operator)
 
 This document explains how to get started with Scalar products monitoring on Kubernetes using Prometheus Operator (kube-prometheus-stack). Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalar-helm-charts.md
+++ b/docs/3.4/helm-charts/getting-started-scalar-helm-charts.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Scalar Helm Charts
 
 This document explains how to get started with Scalar Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalar-manager.md
+++ b/docs/3.4/helm-charts/getting-started-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Helm Charts (Scalar Manager)
 Scalar Manager is a web-based dashboard that allows users to:
 * check the health of the Scalar products

--- a/docs/3.4/helm-charts/getting-started-scalardb.md
+++ b/docs/3.4/helm-charts/getting-started-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # [Deprecated] Getting Started with Helm Charts (ScalarDB Server)
 
 {% capture notice--info %}

--- a/docs/3.4/helm-charts/getting-started-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/getting-started-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)
 
 This document explains how to get started with ScalarDL Ledger and Auditor using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/getting-started-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/getting-started-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)
 
 This document explains how to get started with ScalarDL Ledger using Helm Chart on a Kubernetes cluster as a test environment. Here, we assume that you already have a Mac or Linux environment for testing. We use **Minikube** in this document, but the steps we will show should work in any Kubernetes cluster.

--- a/docs/3.4/helm-charts/how-to-deploy-scalar-manager.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalar-manager.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to deploy Scalar Manager
 
 This document explains how to deploy Scalar Manager using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for Scalar Manager.

--- a/docs/3.4/helm-charts/how-to-deploy-scalar-products.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalar-products.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy Scalar products using Scalar Helm Charts
 
 This document explains how to deploy Scalar products using Scalar Helm Charts. If you want to test Scalar products on your local environment using a minikube cluster, please refer to the following getting started guide.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb-cluster.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb-cluster.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to deploy ScalarDB Cluster
 
 This document explains how to deploy ScalarDB Cluster by using Scalar Helm Charts. For details on the custom values file for ScalarDB Cluster, see [Configure a custom values file for ScalarDB Cluster](./configure-custom-values-scalardb-cluster.md).

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb-graphql.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb-graphql.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # [Deprecated] How to deploy ScalarDB GraphQL
 
 {% capture notice--info %}

--- a/docs/3.4/helm-charts/how-to-deploy-scalardb.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardb.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # [Deprecated] How to deploy ScalarDB Server
 
 {% capture notice--info %}

--- a/docs/3.4/helm-charts/how-to-deploy-scalardl-auditor.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardl-auditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to deploy ScalarDL Auditor
 
 This document explains how to deploy ScalarDL Auditor using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Auditor and ScalarDL Schema Loader.

--- a/docs/3.4/helm-charts/how-to-deploy-scalardl-ledger.md
+++ b/docs/3.4/helm-charts/how-to-deploy-scalardl-ledger.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to deploy ScalarDL Ledger
 
 This document explains how to deploy ScalarDL Ledger using Scalar Helm Charts. You must prepare your custom values file. Please refer to the following document for more details on the custom values file for ScalarDL Ledger and ScalarDL Schema Loader.

--- a/docs/3.4/helm-charts/mount-files-or-volumes-on-scalar-pods.md
+++ b/docs/3.4/helm-charts/mount-files-or-volumes-on-scalar-pods.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Mount any files or volumes on Scalar product pods
 
 You can mount any files or volumes on Scalar product pods when you use ScalarDB Server, ScalarDB Cluster, or ScalarDL Helm Charts (ScalarDL Ledger and ScalarDL Auditor).

--- a/docs/3.4/helm-charts/use-secret-for-credentials.md
+++ b/docs/3.4/helm-charts/use-secret-for-credentials.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to use Secret resources to pass credentials as environment variables into the properties file
 
 You can pass credentials like **username** or **password** as environment variables via a `Secret` resource in Kubernetes. The docker images for previous versions of Scalar products use the `dockerize` command for templating properties files. The docker images for the latest versions of Scalar products get values directly from environment variables.

--- a/docs/3.4/how-to-handle-errors.md
+++ b/docs/3.4/how-to-handle-errors.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A Guide on How to Handle Errors in ScalarDL
 
 This document sets out some guidelines for handling errors in ScalarDL.

--- a/docs/3.4/how-to-use-proof.md
+++ b/docs/3.4/how-to-use-proof.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A Guide on How to Use Asset Proofs in ScalarDL
 
 This document sets out some guidelines for using Asset Proofs in ScalarDL.

--- a/docs/3.4/how-to-write-contract.md
+++ b/docs/3.4/how-to-write-contract.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A Guide on How to Write a Good Contract for ScalarDL
 
 This document sets out some guidelines for writing contracts for ScalarDL.

--- a/docs/3.4/how-to-write-function.md
+++ b/docs/3.4/how-to-write-function.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # A Guide on How to Write Function for ScalarDL
 
 This document sets out some guidelines for writing functions for ScalarDL.

--- a/docs/3.4/implementation.md
+++ b/docs/3.4/implementation.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Implementation
 
 ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems, which achieves correctness, scalability, and database agnosticism.

--- a/docs/3.4/index.md
+++ b/docs/3.4/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL: Byzantine Fault Detection Middleware for Transactional Database Systems
 
 ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.

--- a/docs/3.4/installation-with-docker.md
+++ b/docs/3.4/installation-with-docker.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to install ScalarDL in your local environment with Docker
 
 This document shows how to set up a local environment that runs ScalarDL

--- a/docs/3.4/javadoc/2.1.1/index.md
+++ b/docs/3.4/javadoc/2.1.1/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [client](./client)
 * [common](./common)
 * [ledger](./ledger)

--- a/docs/3.4/javadoc/2.2.0/index.md
+++ b/docs/3.4/javadoc/2.2.0/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [client](./client)
 * [common](./common)
 * [ledger](./ledger)

--- a/docs/3.4/javadoc/3.0.0/index.md
+++ b/docs/3.4/javadoc/3.0.0/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [auditor](./auditor)
 * [client](./client)
 * [common](./common)

--- a/docs/3.4/javadoc/3.0.2/index.md
+++ b/docs/3.4/javadoc/3.0.2/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [auditor](./auditor)
 * [client](./client)
 * [common](./common)

--- a/docs/3.4/javadoc/3.1.0/index.md
+++ b/docs/3.4/javadoc/3.1.0/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [auditor](./auditor)
 * [bfd](./bfd)
 * [client](./client)

--- a/docs/3.4/javadoc/3.2.0/index.md
+++ b/docs/3.4/javadoc/3.2.0/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [auditor](./auditor)
 * [client](./client)
 * [common](./common)

--- a/docs/3.4/javadoc/3.3.0/index.md
+++ b/docs/3.4/javadoc/3.3.0/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 * [auditor](./auditor)
 * [client](./client)
 * [common](./common)

--- a/docs/3.4/javadoc/index.md
+++ b/docs/3.4/javadoc/index.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Scalar DL Javadoc
 
 * [latest](./latest/index.md)

--- a/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/AccessScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications
 
 This document explains how to make ScalarDB or ScalarDL deployed in a Kubernetes cluster environment available from applications. To make ScalarDB or ScalarDL available from applications, you can use Scalar Envoy via a Kubernetes service resource named `<HELM_RELEASE_NAME>-envoy`. You can use `<HELM_RELEASE_NAME>-envoy` in several ways, such as:

--- a/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AwsMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to install Scalar products through AWS Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are available in the AWS Marketplace as container images. This guide explains how to install Scalar products through the AWS Marketplace.

--- a/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
+++ b/docs/3.4/scalar-kubernetes/AzureMarketplaceGuide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # How to install Scalar products through Azure Marketplace
 
 Scalar products (ScalarDB, ScalarDL, and their tools) are provided in Azure Marketplace as container offers. This guide explains how to install Scalar products through Azure Marketplace.

--- a/docs/3.4/scalar-kubernetes/BackupNoSQL.md
+++ b/docs/3.4/scalar-kubernetes/BackupNoSQL.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Back up a NoSQL database in a Kubernetes environment
 
 This guide explains how to create a transactionally consistent backup of managed databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that, when using a NoSQL database or multiple databases, you **must** pause ScalarDB or ScalarDL to create a transactionally consistent backup.

--- a/docs/3.4/scalar-kubernetes/BackupRDB.md
+++ b/docs/3.4/scalar-kubernetes/BackupRDB.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Back up an RDB in a Kubernetes environment
 
 This guide explains how to create a backup of a single relational database (RDB) that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider.

--- a/docs/3.4/scalar-kubernetes/BackupRestoreGuide.md
+++ b/docs/3.4/scalar-kubernetes/BackupRestoreGuide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Back up and restore ScalarDB or ScalarDL data in a Kubernetes environment
 
 This guide explains how to backup and restore ScalarDB or ScalarDL data in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL. The following is a list of the managed databases that this guide assumes you might be using:

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDB.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDB.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDB Server
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDB Server deployment. For details on how to deploy ScalarDB Server on an AKS cluster, see [Deploy ScalarDB Server on AKS](./ManualDeploymentGuideScalarDBServerOnAKS.md).

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDL.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDL.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an AKS cluster, see [Deploy ScalarDL Ledger on AKS](./ManualDeploymentGuideScalarDLOnAKS.md).

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Azure Kubernetes Service (AKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an AKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on AKS](./ManualDeploymentGuideScalarDLAuditorOnAKS.md).

--- a/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/CreateAKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an AKS cluster for Scalar products
 
 To create an Azure Kubernetes Service (AKS) cluster for Scalar products, refer to the following:

--- a/docs/3.4/scalar-kubernetes/CreateBastionServer.md
+++ b/docs/3.4/scalar-kubernetes/CreateBastionServer.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Create a bastion server
 
 This document explains how to create a bastion server and install some tools for the deployment of Scalar products.

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDB.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDB.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # (Deprecated) Guidelines for creating an EKS cluster for ScalarDB Server
 
 {% capture notice--warning %}

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDL.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDL.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an EKS cluster for ScalarDL Ledger
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger deployment. For details on how to deploy ScalarDL Ledger on an EKS cluster, see [Deploy ScalarDL Ledger on Amazon EKS](./ManualDeploymentGuideScalarDLOnEKS.md).

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an EKS cluster for ScalarDL Ledger and ScalarDL Auditor
 
 This document explains the requirements and recommendations for creating an Amazon Elastic Kubernetes Service (EKS) cluster for ScalarDL Ledger and ScalarDL Auditor deployment. For details on how to deploy ScalarDL Ledger and ScalarDL Auditor on an EKS cluster, see [Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon EKS](./ManualDeploymentGuideScalarDLAuditorOnEKS.md).

--- a/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
+++ b/docs/3.4/scalar-kubernetes/CreateEKSClusterForScalarProducts.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Guidelines for creating an Amazon EKS cluster for Scalar products
 
 To create an Amazon Elastic Kubernetes Service (EKS) cluster for Scalar products, refer to the following:

--- a/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sLogCollectionGuide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Collecting logs from Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Grafana Loki and Promtail on Kubernetes with Helm. After following this document, you can collect logs of Scalar products on your Kubernetes environment.

--- a/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
+++ b/docs/3.4/scalar-kubernetes/K8sMonitorGuide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Monitoring Scalar products on a Kubernetes cluster
 
 This document explains how to deploy Prometheus Operator on Kubernetes with Helm. After following this document, you can use Prometheus, Alertmanager, and Grafana for monitoring Scalar products on your Kubernetes environment.

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDB Server on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDB Server on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDBServerOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDB Server on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLAuditorOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS)
 
 This guide explains how to deploy ScalarDL Ledger and ScalarDL Auditor on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnAKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Azure Kubernetes Service (AKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Azure Kubernetes Service (AKS).

--- a/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
+++ b/docs/3.4/scalar-kubernetes/ManualDeploymentGuideScalarDLOnEKS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploy ScalarDL Ledger on Amazon Elastic Kubernetes Service (EKS)
 
 This document explains how to deploy **ScalarDL Ledger** on Amazon Elastic Kubernetes Service (EKS).

--- a/docs/3.4/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/NetworkPeeringForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Configure Network Peering for ScalarDL Auditor Mode
 
 This document explains how to connect multiple private networks for ScalarDL Auditor mode to perform network peering. For ScalarDL Auditor mode to work properly, you must connect ScalarDL Ledger to ScalarDL Auditor.

--- a/docs/3.4/scalar-kubernetes/ProductionChecklistForScalarDLAuditor.md
+++ b/docs/3.4/scalar-kubernetes/ProductionChecklistForScalarDLAuditor.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Production checklist for ScalarDL Auditor
 
 This checklist provides recommendations when deploying ScalarDL Auditor in a production environment.

--- a/docs/3.4/scalar-kubernetes/ProductionChecklistForScalarDLLedger.md
+++ b/docs/3.4/scalar-kubernetes/ProductionChecklistForScalarDLLedger.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Production checklist for ScalarDL Ledger
 
 This checklist provides recommendations when deploying ScalarDL Ledger in a production environment.

--- a/docs/3.4/scalar-kubernetes/RegularCheck.md
+++ b/docs/3.4/scalar-kubernetes/RegularCheck.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Components to Regularly Check When Running in a Kubernetes Environment
 
 Most of the components deployed by manual deployment guides are self-healing with the help of the managed Kubernetes services and Kubernetes self-healing capability. There are also configured alerts that occur when some unexpected behavior happens. Thus, there shouldn't be so many things to do day by day for the deployment of Scalar products on the managed Kubernetes cluster. However, it is recommended to check the status of a system on a regular basis to see if everything is working fine. Here is the list of things you might want to do on a regular basis.

--- a/docs/3.4/scalar-kubernetes/RestoreDatabase.md
+++ b/docs/3.4/scalar-kubernetes/RestoreDatabase.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Restore databases in a Kubernetes environment
 
 This guide explains how to restore databases that ScalarDB or ScalarDL uses in a Kubernetes environment. Please note that this guide assumes that you are using a managed database from a cloud services provider as the backend database for ScalarDB or ScalarDL.

--- a/docs/3.4/scalar-kubernetes/SetupDatabase.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabase.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on cloud services.

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAWS.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on AWS
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on AWS.

--- a/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
+++ b/docs/3.4/scalar-kubernetes/SetupDatabaseForAzure.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Set up a database for ScalarDB/ScalarDL deployment on Azure
 
 This guide explains how to set up a database for ScalarDB/ScalarDL deployment on Azure.

--- a/docs/3.4/scalar-kubernetes/alerts/README.md
+++ b/docs/3.4/scalar-kubernetes/alerts/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Scalar Alerts
 
 This section covers the types of alerts and what actions need to be taken.

--- a/docs/3.4/scalar-kubernetes/deploy-kubernetes.md
+++ b/docs/3.4/scalar-kubernetes/deploy-kubernetes.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Deploying ScalarDL on Managed Kubernetes Services
 
 The following documentation is to help you set up and deploy a ScalarDL environment on managed Kubernetes services.

--- a/docs/3.4/scalar-kubernetes/manage-kubernetes.md
+++ b/docs/3.4/scalar-kubernetes/manage-kubernetes.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Managing ScalarDL on Managed Kubernetes Services
 
 The following documentation is to help you manage a ScalarDL environment on managed Kubernetes services.

--- a/docs/3.4/scalardl-benchmarks/README.md
+++ b/docs/3.4/scalardl-benchmarks/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Benchmarks
 
 This repository contains benchmark programs for ScalarDL.

--- a/docs/3.4/scalardl-go-client-sdk/README.md
+++ b/docs/3.4/scalardl-go-client-sdk/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Scalar DL Go Client SDK
 This module is for developing applications that interact with [Scalar DL](https://github.com/scalar-labs/scalardl) networks.
 

--- a/docs/3.4/scalardl-java-client-sdk/README.md
+++ b/docs/3.4/scalardl-java-client-sdk/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 ## Scalar DL Java Client SDK
 
 This is a client-side Java library to interact with [Scalar DL](https://github.com/scalar-labs/scalardl) network.

--- a/docs/3.4/scalardl-javascript-sdk-base/README.md
+++ b/docs/3.4/scalardl-javascript-sdk-base/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 [![CircleCI](https://circleci.com/gh/scalar-labs/scalardl-javascript-sdk-base/tree/master.svg?style=svg)](https://circleci.com/gh/scalar-labs/scalardl-javascript-sdk-base/tree/master)
 
 NPM package `@scalar-labs/scalardl-javascript-sdk-base` is the common part for package [@scalar-labs/scalardl-web-client-sdk](https://github.com/scalar-labs/scalardl-web-client-sdk) and [@scalar-labs/scalardl-node-client-sdk](https://github.com/scalar-labs/scalardl-node-client-sdk).

--- a/docs/3.4/scalardl-node-client-sdk/README.md
+++ b/docs/3.4/scalardl-node-client-sdk/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Scalar DL Node Client SDK
 
 This is a library for Node.js applications by which the applications can interact with a [Scalar DL](https://github.com/scalar-labs/scalardl) network.

--- a/docs/3.4/scalardl-web-client-sdk/README.md
+++ b/docs/3.4/scalardl-web-client-sdk/README.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 ## Scalar DL Web Client SDK
 
 This is a library for web applications by which the applications can interact with a [Scalar DL](https://github.com/scalar-labs/scalardl) network.

--- a/docs/3.4/schema-loader.md
+++ b/docs/3.4/schema-loader.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # ScalarDL Schema Loader
 
 A Docker image that loads the database schemas of ScalarDL using [Schema Tool for Scalar DB](https://github.com/scalar-labs/scalardb/tree/master/schema-loader/).

--- a/docs/3.4/sdks.md
+++ b/docs/3.4/sdks.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # SDKs for ScalarDL
 
 The following is a list of SDKs for ScalarDL:

--- a/docs/3.4/troubleshooting-guide.md
+++ b/docs/3.4/troubleshooting-guide.md
@@ -1,3 +1,5 @@
+{% include scalardl/end-of-support.html %}
+
 # Troubleshooting Guide
 
 # Introduction


### PR DESCRIPTION
## Description

This PR adds an out-of-support banner to the top of docs for ScalarDL 3.4.

## Related issues and/or PRs

N/A

## Changes made

- Added an out-of-support banner to the top of docs for ScalarDL.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A