### PR TITLE
Add language dropdown menu to see docs in Japanese

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -164,6 +164,21 @@ defaults:
       search: false
       classes: wide # Expands the page to take up space where the TOC would normally be.
 
+  # _home - Do not change the `_home` scope.
+  - scope:
+      path: "_home/ja-jp" # Specifies the name of the folder where the parent product docs home page, error page, and other common pages are located.
+      type: home # Specifies the collection type for the parent product home page.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp"
+      toc: false
+      toc_sticky: false
+      search: false
+      classes: wide # Expands the page to take up space where the TOC would normally be.
+
   ############### Template for versions. When adding a new version (`scope`), copy this template and replace `<VERSION>` with the version number`,  and change `search` for the previous version to `false`. ###############
 
   # # <VERSION>
@@ -286,6 +301,101 @@ defaults:
       share: false # Shows social media buttons to share pages.
       sidebar: # Shows side navigation content from `_data/navigation.yml`.
         nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
+
+  # latest - Japanese docs
+  - scope:
+      path: "docs/ja-jp/latest" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
+  # 3.8 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.8" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
+  # 3.7 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.7" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.7-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  # 3.6 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.6" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # show the average reading time for the page
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.6-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  # 3.5 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.5" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.5-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  
+  # Release notes - Japanese docs
+  - scope:
+      path: "docs/ja-jp/releases" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
+  # Common docs in the `docs` root folder - Japanese docs
+  - scope:
+      path: "docs/ja-jp" # Specifies the name of the folder where the common docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
       toc: true
       toc_sticky: true
       search: false

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,26 +1,27 @@
 # Site Header
 # Make sure the `main` navigation in the `/_data/navigation.yml` file matches across all `docs-[scalar-product]` repos.
 main:
-  - title: "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Home&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+  - title: "&nbsp;&nbsp;&nbsp;Home&nbsp;&nbsp;&nbsp;"
     url: https://www.scalar-labs.com/
-  - title: "Products"
-    children:
-      - title: "ScalarDB"
-        description: Database-agnostic universal transaction manager for achieving ACID transactions
-        url: https://www.scalar-labs.com/scalardb/
-      - title: "ScalarDL"
-        url: https://www.scalar-labs.com/scalardl/
-        description: Scalable, practical Byzantine-fault detection middleware for transactional database systems
-  - title: "Company"
-    children:
-      - title: "About us"
-        description: Company profile and information
-        url: https://www.scalar-labs.com/about-us/
-      - title: "News"
-        description: Announcements, product news, and case studies
-        url:  https://www.scalar-labs.com/news/
-  - title: "&nbsp;&nbsp;&nbsp;Pricing&nbsp;&nbsp;&nbsp;"
-    url: https://www.scalar-labs.com/pricing/
+  # Removed the following menu items because the heading (masthead) is getting too crowded (modified by josh-wong).
+  # - title: "Products"
+  #   children:
+  #     - title: "ScalarDB"
+  #       description: Database-agnostic universal transaction manager for achieving ACID transactions
+  #       url: https://www.scalar-labs.com/scalardb/
+  #     - title: "ScalarDL"
+  #       url: https://www.scalar-labs.com/scalardl/
+  #       description: Scalable, practical Byzantine-fault detection middleware for transactional database systems
+  # - title: "Company"
+  #   children:
+  #     - title: "About us"
+  #       description: Company profile and information
+  #       url: https://www.scalar-labs.com/about-us/
+  #     - title: "News"
+  #       description: Announcements, product news, and case studies
+  #       url:  https://www.scalar-labs.com/news/
+  # - title: "&nbsp;&nbsp;&nbsp;Pricing&nbsp;&nbsp;&nbsp;"
+  #   url: https://www.scalar-labs.com/pricing/
   - title: "&nbsp;&nbsp;&nbsp;Support&nbsp;&nbsp;&nbsp;"
     url: https://www.scalar-labs.com/support/
   

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -23,6 +23,14 @@ main:
     url: https://www.scalar-labs.com/pricing/
   - title: "&nbsp;&nbsp;&nbsp;Support&nbsp;&nbsp;&nbsp;"
     url: https://www.scalar-labs.com/support/
+  
+languages:
+  - language-title-top: ""
+    language-children:
+      - language-title: "English"
+        language-url: /docs/
+      - language-title: "日本語"
+        language-url: /docs/ja-jp/
 
 # This navigation is for adding product versions that appear in the dropdown menu. Make sure the latest version is labeled `<VERSION> (latest)`.
 versions:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -587,3 +587,435 @@ versions:
       #   url: /docs/releases/release-3.4/
       # - title: "Release Support Policy"
       #   url: /docs/releases/release-support-policy
+
+"latest-ja-jp":
+  - title: "⬅ ScalarDLドキュメンテーションホーム" 
+    url: /docs/ja-jp # Don't change this URL. This links back to the parent product home page.
+  - title: "ScalarDL 3.8"
+    children:
+  # Get Started docs
+  - title: "始めましょう"
+    children:
+      - title: "ScalarDLの入門"
+        url: /docs/ja-jp/latest/getting-started/
+      - title: "ScalarDL Auditor の概要"
+        url: /docs/ja-jp/latest/getting-started-auditor/
+  # Samples docs
+  - title: "サンプル" 
+    children:
+      - title: "簡単な銀行口座申請"
+        url: /docs/ja-jp/latest/applications/simple-bank-account/README/
+      # - title: "API endpoints"
+      #   url: /docs/ja-jp/latest/applications/simple-bank-account/docs/api_endpoints/
+      - title: "ScalarDLエスクロー支払い CLI"
+        url: /docs/ja-jp/latest/applications/escrow-payment/README/
+  # Develop docs
+  - title: "開発する"
+    children:
+      - title: "ScalarDL 用の SDK"
+        url: /docs/ja-jp/latest/sdks/
+      - title: "ScalarDL Schema Loader"
+        url: /docs/ja-jp/latest/schema-loader/
+      - title: "ScalarDL でアセットプルーフを使用する方法"
+        url: /docs/ja-jp/latest/how-to-use-proof/
+      - title: "ScalarDL の適切なコントラクトを作成する方法"
+        url: /docs/ja-jp/latest/how-to-write-contract/
+      - title: "ScalarDL の関数の書き方"
+        url: /docs/ja-jp/latest/how-to-write-function/
+      - title: "証明書の取得方法"
+        url: /docs/ja-jp/latest/ca/caclient-getting-started/
+      - title: "ScalarDL 認証ガイド"
+        url: /docs/ja-jp/latest/authentication/
+      - title: "ScalarDL でのエラーの処理方法"
+        url: /docs/ja-jp/latest/how-to-handle-errors/
+  # Deploy docs
+  - title: "展開する"
+    children:
+      - title: "マネージド Kubernetes サービスへの ScalarDL のデプロイ"
+        url: /docs/ja-jp/latest/scalar-kubernetes/deploy-kubernetes/
+      - title: "Docker を使用してローカル環境に ScalarDL をインストールする方法"
+        url: /docs/ja-jp/latest/installation-with-docker/
+      - title: "Scalar Helm Chartsの入門"
+        url: /docs/ja-jp/latest/helm-charts/getting-started-scalar-helm-charts/
+      - title: "Helm Chartsの入門 (ScalarDL Ledger および Auditor / Auditor モード)"
+        url: /docs/ja-jp/latest/helm-charts/getting-started-scalardl-auditor/
+      - title: "Helm Chartsの入門 (ScalarDL Ledger / Ledger のみ)"
+        url: /docs/ja-jp/latest/helm-charts/getting-started-scalardl-ledger/
+      - title: "Scalar Helm Chartsのカスタム値ファイルを構成する"
+        url: /docs/ja-jp/latest/helm-charts/configure-custom-values-file/
+      - title: "Scalar Helm Chart を使用して Scalar 製品をデプロイする"
+        url: /docs/ja-jp/latest/helm-charts/how-to-deploy-scalar-products/
+      - title: "Scalar 製品ポッドにファイルまたはボリュームをマウントします"
+        url: /docs/ja-jp/latest/helm-charts/mount-files-or-volumes-on-scalar-pods/
+      - title: "Secret リソースを使用して資格情報を環境変数としてプロパティ ファイルに渡す方法"
+        url: /docs/ja-jp/latest/helm-charts/use-secret-for-credentials/
+      - title: "CFSSL を使用して CA サーバーを起動する方法"
+        url: /docs/ja-jp/latest/ca/caserver-getting-started/
+  # Manage docs
+  - title: "管理"
+    children:
+      - title: "ScalarDL でデータをバックアップおよび復元する方法"
+        url: /docs/ja-jp/latest/backup-restore/
+      - title: "トラブルシューティングガイド"
+        url: /docs/ja-jp/latest/troubleshooting-guide/
+      - title: "マネージド Kubernetes サービスでの ScalarDL の管理"
+        url: /docs/ja-jp/latest/scalar-kubernetes/manage-kubernetes/
+      - title: "Kubernetes の ScalarDL アラート"
+        url: /docs/ja-jp/latest/scalar-kubernetes/alerts/README/
+  # Migrate docs
+  # - title: "Migrate"
+  #   children:
+  #     - title: "<DOC_TITLE>"
+  #       url: /docs/<VERSION>/<URL>/
+  # Reference docs
+  - title: "参照"
+    children:      
+      - title: "ScalarDL設計書"
+        url: /docs/ja-jp/latest/design/
+      - title: "ScalarDL 互換性マトリックス"
+        url: /docs/ja-jp/latest/compatibility/
+      - title: "ScalarDL の実装"
+        url: /docs/ja-jp/latest/implementation/
+      - title: "ScalarDL ベンチマーク"
+        url: /docs/ja-jp/latest/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "リリース"
+    children:
+      - title: "リリースノート"
+        url: /docs/ja-jp/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
+
+"3.7-ja-jp":
+  - title: "⬅ ScalarDLドキュメンテーションホーム" 
+    url: /docs/ja-jp # Don't change this URL. This links back to the parent product home page.
+  - title: "ScalarDL 3.7"
+    children:
+  # Get Started docs
+  - title: "始めましょう"
+    children:
+      - title: "ScalarDLの入門"
+        url: /docs/ja-jp/3.7/getting-started/
+      - title: "ScalarDL Auditorの概要"
+        url: /docs/ja-jp/3.7/getting-started-auditor/
+  # Samples docs
+  - title: "サンプル" 
+    children:
+      - title: "簡単な銀行口座申請"
+        url: /docs/ja-jp/3.7/applications/simple-bank-account/README/
+      # - title: "API endpoints"
+      #   url: /docs/ja-jp/3.7/applications/simple-bank-account/docs/api_endpoints/
+      - title: "ScalarDL Escrow payment CLI"
+        url: /docs/ja-jp/3.7/applications/escrow-payment/README/
+  # Develop docs
+  - title: "Develop"
+    children:
+      - title: "SDKs for ScalarDL"
+        url: /docs/ja-jp/3.7/sdks/
+      - title: "ScalarDL Schema Loader"
+        url: /docs/ja-jp/3.7/schema-loader/
+      - title: "How to Use Asset Proofs in ScalarDL"
+        url: /docs/ja-jp/3.7/how-to-use-proof/
+      - title: "How to Write a Good Contract for ScalarDL"
+        url: /docs/ja-jp/3.7/how-to-write-contract/
+      - title: "How to Write Function for ScalarDL"
+        url: /docs/ja-jp/3.7/how-to-write-function/
+      - title: "How to get a certificate"
+        url: /docs/ja-jp/3.7/ca/caclient-getting-started/
+      - title: "ScalarDL Authentication Guide"
+        url: /docs/ja-jp/3.7/authentication/
+      - title: "How to Handle Errors in ScalarDL"
+        url: /docs/ja-jp/3.7/how-to-handle-errors/
+  # Deploy docs
+  - title: "Deploy"
+    children:
+      - title: "Deploying ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.7/scalar-kubernetes/deploy-kubernetes/
+      - title: "How to install ScalarDL in your local environment with Docker"
+        url: /docs/ja-jp/3.7/installation-with-docker/
+      - title: "Getting Started with Scalar Helm Charts"
+        url: /docs/ja-jp/3.7/helm-charts/getting-started-scalar-helm-charts/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)"
+        url: /docs/ja-jp/3.7/helm-charts/getting-started-scalardl-auditor/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)"
+        url: /docs/ja-jp/3.7/helm-charts/getting-started-scalardl-ledger/
+      - title: "Configure a custom values file for Scalar Helm Charts"
+        url: /docs/ja-jp/3.7/helm-charts/configure-custom-values-file/
+      - title: "Deploy Scalar products using Scalar Helm Charts"
+        url: /docs/ja-jp/3.7/helm-charts/how-to-deploy-scalar-products/
+      - title: "Mount any files or volumes on Scalar product pods"
+        url: /docs/ja-jp/3.7/helm-charts/mount-files-or-volumes-on-scalar-pods/
+      - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
+        url: /docs/ja-jp/3.7/helm-charts/use-secret-for-credentials/
+      - title: "How to start CA server with CFSSL"
+        url: /docs/ja-jp/3.7/ca/caserver-getting-started/
+  # Manage docs
+  - title: "Manage"
+    children:
+      - title: "How to Backup and Restore Data in ScalarDL"
+        url: /docs/ja-jp/3.7/backup-restore/
+      - title: "Troubleshooting Guide"
+        url: /docs/ja-jp/3.7/troubleshooting-guide/
+      - title: "Managing ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.7/scalar-kubernetes/manage-kubernetes/
+      - title: "ScalarDL Alerts in Kubernetes"
+        url: /docs/ja-jp/3.7/scalar-kubernetes/alerts/README/
+  # Migrate docs
+  # - title: "Migrate"
+  #   children:
+  #     - title: "<DOC_TITLE>"
+  #       url: /docs/<VERSION>/<URL>/
+  # Reference docs
+  - title: "Reference"
+    children:      
+      - title: "ScalarDL design document"
+        url: /docs/ja-jp/3.7/design/
+      - title: "ScalarDL Compatibility Matrix"
+        url: /docs/ja-jp/3.7/compatibility/
+      - title: "ScalarDL Implementation"
+        url: /docs/ja-jp/3.7/implementation/
+      - title: "ScalarDL Benchmarks"
+        url: /docs/ja-jp/3.7/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/ja-jp/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
+
+"3.6-ja-jp":
+  - title: "⬅ ScalarDLドキュメンテーションホーム" 
+    url: /docs/ja-jp # Don't change this URL. This links back to the parent product home page.
+  - title: "ScalarDL 3.6"
+    children:
+  # Get Started docs
+  - title: "始めましょう"
+    children:
+      - title: "Getting Started with ScalarDL"
+        url: /docs/ja-jp/3.6/getting-started/
+      - title: "Getting Started with ScalarDL Auditor"
+        url: /docs/ja-jp/3.6/getting-started-auditor/
+  # Samples docs
+  - title: "Samples" 
+    children:
+      - title: "A simple bank account application"
+        url: /docs/ja-jp/3.6/applications/simple-bank-account/README/
+      # - title: "API endpoints"
+      #   url: /docs/ja-jp/3.6/applications/simple-bank-account/docs/api_endpoints/
+      - title: "ScalarDL Escrow payment CLI"
+        url: /docs/ja-jp/3.6/applications/escrow-payment/README/
+  # Develop docs
+  - title: "Develop"
+    children:
+      - title: "SDKs for ScalarDL"
+        url: /docs/ja-jp/3.6/sdks/
+      - title: "ScalarDL Schema Loader"
+        url: /docs/ja-jp/3.6/schema-loader/
+      - title: "How to Use Asset Proofs in ScalarDL"
+        url: /docs/ja-jp/3.6/how-to-use-proof/
+      - title: "How to Write a Good Contract for ScalarDL"
+        url: /docs/ja-jp/3.6/how-to-write-contract/
+      - title: "How to Write Function for ScalarDL"
+        url: /docs/ja-jp/3.6/how-to-write-function/
+      - title: "How to get a certificate"
+        url: /docs/ja-jp/3.6/ca/caclient-getting-started/
+      - title: "ScalarDL Authentication Guide"
+        url: /docs/ja-jp/3.6/authentication/
+      - title: "How to Handle Errors in ScalarDL"
+        url: /docs/ja-jp/3.6/how-to-handle-errors/
+  # Deploy docs
+  - title: "Deploy"
+    children:
+      - title: "Deploying ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.6/scalar-kubernetes/deploy-kubernetes/
+      - title: "How to install ScalarDL in your local environment with Docker"
+        url: /docs/ja-jp/3.6/installation-with-docker/
+      - title: "Getting Started with Scalar Helm Charts"
+        url: /docs/ja-jp/3.6/helm-charts/getting-started-scalar-helm-charts/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)"
+        url: /docs/ja-jp/3.6/helm-charts/getting-started-scalardl-auditor/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)"
+        url: /docs/ja-jp/3.6/helm-charts/getting-started-scalardl-ledger/
+      - title: "Configure a custom values file for Scalar Helm Charts"
+        url: /docs/ja-jp/3.6/helm-charts/configure-custom-values-file/
+      - title: "Deploy Scalar products using Scalar Helm Charts"
+        url: /docs/ja-jp/3.6/helm-charts/how-to-deploy-scalar-products/
+      - title: "Mount any files or volumes on Scalar product pods"
+        url: /docs/ja-jp/3.6/helm-charts/mount-files-or-volumes-on-scalar-pods/
+      - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
+        url: /docs/ja-jp/3.6/helm-charts/use-secret-for-credentials/
+      - title: "How to start CA server with CFSSL"
+        url: /docs/ja-jp/3.6/ca/caserver-getting-started/
+  # Manage docs
+  - title: "Manage"
+    children:
+      - title: "How to Backup and Restore Data in ScalarDL"
+        url: /docs/ja-jp/3.6/backup-restore/
+      - title: "Troubleshooting Guide"
+        url: /docs/ja-jp/3.6/troubleshooting-guide/
+      - title: "Managing ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.6/scalar-kubernetes/manage-kubernetes/
+      - title: "ScalarDL Alerts in Kubernetes"
+        url: /docs/ja-jp/3.6/scalar-kubernetes/alerts/README/
+  # Migrate docs
+  # - title: "Migrate"
+  #   children:
+  #     - title: "<DOC_TITLE>"
+  #       url: /docs/<VERSION>/<URL>/
+  # Reference docs
+  - title: "Reference"
+    children:      
+      - title: "ScalarDL design document"
+        url: /docs/ja-jp/3.6/design/
+      - title: "ScalarDL Compatibility Matrix"
+        url: /docs/ja-jp/3.6/compatibility/
+      - title: "ScalarDL Implementation"
+        url: /docs/ja-jp/3.6/implementation/
+      - title: "ScalarDL Benchmarks"
+        url: /docs/ja-jp/3.6/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/ja-jp/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy
+
+"3.5-ja-jp":
+  - title: "⬅ ScalarDLドキュメンテーションホーム" 
+    url: /docs/ja-jp # Don't change this URL. This links back to the parent product home page.
+  - title: "ScalarDL 3.5"
+    children:
+  # Get Started docs
+  - title: "始めましょう"
+    children:
+      - title: "Getting Started with ScalarDL"
+        url: /docs/ja-jp/3.5/getting-started/
+      - title: "Getting Started with ScalarDL Auditor"
+        url: /docs/ja-jp/3.5/getting-started-auditor/
+  # Samples docs
+  - title: "Samples" 
+    children:
+      - title: "A simple bank account application"
+        url: /docs/ja-jp/3.5/applications/simple-bank-account/README
+      # - title: "API endpoints"
+      #   url: /docs/ja-jp/3.5/applications/simple-bank-account/docs/api_endpoints
+      - title: "ScalarDL Escrow payment CLI"
+        url: /docs/ja-jp/3.5/applications/escrow-payment/README
+  # Develop docs
+  - title: "Develop"
+    children:
+      - title: "SDKs for ScalarDL"
+        url: /docs/ja-jp/3.5/sdks/
+      - title: "ScalarDL Schema Loader"
+        url: /docs/ja-jp/3.5/schema-loader/
+      - title: "How to Use Asset Proofs in ScalarDL"
+        url: /docs/ja-jp/3.5/how-to-use-proof/
+      - title: "How to Write a Good Contract for ScalarDL"
+        url: /docs/ja-jp/3.5/how-to-write-contract/
+      - title: "How to Write Function for ScalarDL"
+        url: /docs/ja-jp/3.5/how-to-write-function/
+      - title: "How to get a certificate"
+        url: /docs/ja-jp/3.5/ca/caclient-getting-started/
+      - title: "ScalarDL Authentication Guide"
+        url: /docs/ja-jp/3.5/authentication/
+      - title: "How to Handle Errors in ScalarDL"
+        url: /docs/ja-jp/3.5/how-to-handle-errors/
+  # Deploy docs
+  - title: "Deploy"
+    children:
+      - title: "Deploying ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.5/scalar-kubernetes/deploy-kubernetes/
+      - title: "How to install ScalarDL in your local environment with Docker"
+        url: /docs/ja-jp/3.5/installation-with-docker/
+      - title: "Getting Started with Scalar Helm Charts"
+        url: /docs/ja-jp/3.5/helm-charts/getting-started-scalar-helm-charts/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger and Auditor / Auditor mode)"
+        url: /docs/ja-jp/3.5/helm-charts/getting-started-scalardl-auditor/
+      - title: "Getting Started with Helm Charts (ScalarDL Ledger / Ledger only)"
+        url: /docs/ja-jp/3.5/helm-charts/getting-started-scalardl-ledger/
+      - title: "Configure a custom values file for Scalar Helm Charts"
+        url: /docs/ja-jp/3.5/helm-charts/configure-custom-values-file/
+      - title: "Deploy Scalar products using Scalar Helm Charts"
+        url: /docs/ja-jp/3.5/helm-charts/how-to-deploy-scalar-products/
+      - title: "Mount any files or volumes on Scalar product pods"
+        url: /docs/ja-jp/3.5/helm-charts/mount-files-or-volumes-on-scalar-pods/
+      - title: "How to use Secret resources to pass the credentials as the environment variables into the properties file"
+        url: /docs/ja-jp/3.5/helm-charts/use-secret-for-credentials/
+      - title: "How to start CA server with CFSSL"
+        url: /docs/ja-jp/3.5/ca/caserver-getting-started/
+  # Manage docs
+  - title: "Manage"
+    children:
+      - title: "How to Backup and Restore Data in ScalarDL"
+        url: /docs/ja-jp/3.5/backup-restore/
+      - title: "Troubleshooting Guide"
+        url: /docs/ja-jp/3.5/troubleshooting-guide/
+      - title: "Managing ScalarDL on Managed Kubernetes Services"
+        url: /docs/ja-jp/3.5/scalar-kubernetes/manage-kubernetes/
+      - title: "ScalarDL Alerts in Kubernetes"
+        url: /docs/ja-jp/3.5/scalar-kubernetes/alerts/README/
+  # Migrate docs
+  # - title: "Migrate"
+  #   children:
+  #     - title: "<DOC_TITLE>"
+  #       url: /docs/<VERSION>/<URL>/
+  # Reference docs
+  - title: "Reference"
+    children:      
+      - title: "ScalarDL design document"
+        url: /docs/ja-jp/3.5/design/
+      - title: "ScalarDL Compatibility Matrix"
+        url: /docs/ja-jp/3.5/compatibility/
+      - title: "ScalarDL Implementation"
+        url: /docs/ja-jp/3.5/implementation/
+      - title: "ScalarDL Benchmarks"
+        url: /docs/ja-jp/3.5/scalardl-benchmarks/README/
+  # Release docs and notes
+  - title: "Releases"
+    children:
+      - title: "Release Notes"
+        url: /docs/ja-jp/releases/
+      # - title: "v3.8"
+      #   url: /docs/releases/release-3.8/
+      # - title: "v3.7"
+      #   url: /docs/releases/release-3.7/
+      # - title: "v3.6"
+      #   url: /docs/releases/release-3.6/
+      # - title: "v3.5"
+      #   url: /docs/releases/release-3.5/
+      # - title: "v3.4"
+      #   url: /docs/releases/release-3.4/
+      # - title: "Release Support Policy"
+      #   url: /docs/releases/release-support-policy

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -38,11 +38,39 @@
               </li>
             {% endif %}
           {% endfor %}
-        </ul>
+          </ul>
+
         <!-- Adds support for dark mode (added by josh-wong). -->
         {% if site.minimal_mistakes_skin_dark %}
         <i class="fas fa-fw fa-lightbulb btn-light-dark-mode" aria-hidden="true" onclick="node1=document.getElementById('theme_source');node2=document.getElementById('theme_source_2');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');} return false;"></i>
         {% endif %}
+
+        <!-- Adds support for the language switcher icon for the languages listed in `_data/navigation.yml` (added by josh-wong). -->
+        <nav id="site-nav" class="language-greedy-nav">
+          <ul class="language-visible-links">
+          {%- for link in site.data.navigation.languages -%}
+            {% assign class = nil %}
+            {% if page.language-url contains link.language-url %}
+              {% assign class = 'active' %}
+            {% endif %}
+            {% if link.language-children %}
+            <li class="language-dropdown {{ class }}">
+              <label for="touch-language"><a class="language-dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">&nbsp;&nbsp;<i class="fas fa-language fa-2x language-toggle" aria-hidden="true"></i><span><svg class="language-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-language">
+              <ul class="language-dropdown-content">
+                {% for language-children in link.language-children %}
+                  <li>
+                    <a href="{{ site.baseurl }}{{ language-children.language-url }}">
+                      <span>{{ language-children.language-title }}</span>
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+          {% endfor %}
+          </ul>
+        </nav>
 
         {% if site.search == true %}
         <button class="search__toggle" type="button">

--- a/_sass/minimal-mistakes/_masthead.scss
+++ b/_sass/minimal-mistakes/_masthead.scss
@@ -97,3 +97,173 @@
     }
   }
   
+  /* Add styles to support the switcher for languages in `masthead.html`, which are specified in `navigation.yml` (added by josh-wong) */
+  
+  .language-greedy-nav {
+    position: relative;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    min-height: $nav-height;
+    /* width: 190px; */
+    margin-bottom: -0.25em;
+    
+    /* Added to hide the language dropdown menu on mobile and narrow screens since it makes the Scalar logo tiny (added by josh-wong). */
+    // @media screen and (max-width: $small) {
+    //   display: none;
+    // }
+
+      a {
+        display: block;
+        padding: 0.3em 0 0.2em 0;
+        color: $background-color;
+        text-decoration: none;
+        -webkit-transition: none;
+        transition: none;
+        font-size: $type-size-5-25;
+    
+        &:hover {
+          color: $background-color;
+        }
+      }
+    }
+    
+    .language-visible-links {
+      display: -webkit-box;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-pack: end;
+      -ms-flex-pack: end;
+      justify-content: flex-start;
+      -webkit-box-flex: 1;
+      -ms-flex: 1;
+      flex: 1;
+      /* overflow: hidden; */
+      /* max-width: fit-content; */
+    
+      li {
+        -webkit-box-flex: 0;
+        -ms-flex: none;
+        flex: none;
+        font-size: $type-size-5;
+        background-color: $background-color;
+      }
+    
+      a {
+        position: relative;
+        color: $background-color;
+        cursor: pointer;
+        opacity: unset;
+    
+        &:before {
+          content: "";
+          position: absolute;
+          left: 0;
+          bottom: 0;
+          height: 0px; /* Modified to remove the gray underline when hovering over links in the header navigation in `masthead.html`; originally `4px;` (modified by josh-wong) */
+          background: $primary-color;
+          width: 100%;
+          -webkit-transition: $global-transition;
+          transition: $global-transition;
+          -webkit-transform: scaleX(0) translate3d(0, 0, 0);
+          transform: scaleX(0) translate3d(0, 0, 0); // hide
+        }
+    
+        &:hover:before {
+          -webkit-transform: scaleX(1);
+          -ms-transform: scaleX(1);
+          transform: scaleX(1); // reveal
+        }
+      }
+    
+      .language-toggle {
+        color: $language-toggle;
+      }
+
+      .language-dropdown {
+        float: left;
+        /* width: 210px; */
+        min-width: 100%;
+        /* max-width: 75%; */
+        font-size: $type-size-5;
+        font-weight: 500;
+        vertical-align: middle;
+        cursor: default;
+        /* background-color: $scalar-light-gray-background-color; */
+        /* outline-color: $scalar-primary-color; */
+        margin: 0 0 -0.25em 0;
+  
+        li {
+          line-height: 1em;
+        }
+        /* &:hover {
+          background-color: mix($gray, $background-color, 20%);
+        } */
+      }
+    
+      .language-dropdown-arrow {
+        max-width: 20px;
+        vertical-align: middle;
+        padding-top: 2px;
+        float: right;
+      }
+    
+      .language-dropdown-content {
+        display: none;
+        position: absolute;
+        background-color: $background-color;
+        box-shadow: $box-shadow;
+        z-index: 21;
+        border: 1pt solid $border-color;
+        /* width: 210px; */
+        min-width: 100%;
+        /* max-width: 75%; */
+        padding-top: 5px;
+        padding-bottom: 5px;
+  
+        li {
+          padding: 0;
+          margin: 0;
+        }
+      }
+    
+      .language-dropdown-content a {
+        padding: 0 15px 0 15px;
+        margin: 1px;
+        color: $dark-gray;
+        line-height: 1.6em;
+        margin-bottom: 0;
+      }
+    
+      /* Adds support for a clickable language dropdown menu (added by josh-wong) */
+      #touch-language {
+        position: absolute;
+        opacity: 0;
+        height: 0px;
+      }    
+  
+      #touch-language:checked + .language-dropdown-content {
+        min-height: 100%;
+        display: block;
+      }
+  
+      /* The following dropdown method is `hover`, which is the default behavior in Minimal Mistakes theme. Comment this out if we want the dropdown to be clicked on rather than hovered over to access (modified by josh-wong).
+      .language-dropdown:hover .language-dropdown-content {
+        display: block;
+      } */
+    
+      .language-dropdown-content a:hover {
+        background-color: $scalar-light-gray-background-color;
+      }
+    
+      .language-dropdown-content a:not(:last-child) {
+        border-bottom: none; 
+      }
+    }
+
+    .hidden {
+      display: none;
+    }

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -74,6 +74,7 @@ $muted-text-color: mix(#fff, $text-color, 20%) !default;
 $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;
+$language-toggle: #3C4143 !default;
 
 /* Scalar colors (added by josh-wong) */
 $scalar-primary-color: #2673BB !default;

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -13,6 +13,7 @@ $gray: #7a8288 !default;
 $dark-gray: #eaeaea !default; /* This color isn't really gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
 $form-background-color: mix(#000, $background-color, 15%) !default;
 $footer-background-color: mix(#000, $background-color, 30%) !default;
+$language-toggle: #E9EAEB !default;
 $lighter-gray: mix(#fff, $gray, 90%) !default;
 $link-color: mix(#fff, #2673BB, 20%) !default;
 $link-color-hover: mix(#fff, $link-color, 50%) !default;


### PR DESCRIPTION
> [!WARNING]
> 
> Don't merge this PR until **after** we've added docs in Japanese to this docs site.

## Description

This PR adds a language dropdown menu so that visitors can see the docs in either English or Japanese.

## Related issues and/or PRs

N/A

## Changes made

- Added a language dropdown menu and the necessary styles to the heading of the docs site.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A