### PR TITLE
Re-add workflow to update the "docs/latest" folder

### DIFF
--- a/.github/workflows/update-latest-docs.yml
+++ b/.github/workflows/update-latest-docs.yml
@@ -1,0 +1,33 @@
+# Workflow for updating the `latest` folder to include the same content as the latest version of docs
+name: 🔄 Update latest version of docs
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "docs/3.8" # This path *must* match the folder name of the latest product release version.
+  # The following `workflow_dispatch` lines are for scheduling this workflow to reduce GitHub actions. We might want to consider scheduling docs to sync to the docs site repos in the future if we use too many action minutes in our monthly GitHub quota.
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: '0 1 * * 1,4' # Run at 1:00 AM Universal Time Coordinated (UTC) / 10:00 AM Japan Standard Time (JST) on Mondays and Thursdays.
+
+jobs:
+  update-latest-version-of-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update the `latest` folder to include the same content as the latest version of docs
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
+        with:
+          source_file: "docs/3.8/" # This path *must* match the folder name of the latest version.
+          destination_repo: "scalar-labs/docs-scalardl" # Target repo
+          destination_folder: "docs/latest/" # Folder to sync to
+          destination_branch_create: "scalardl/update-docs-latest"
+          user_name: "josh-wong"
+          user_email: "joshua.wong@scalar-labs.com"
+          commit_message: "AUTO: Update the latest version of docs"
+          use_rsync: rsync -avh

--- a/.github/workflows/update-latest-docs.yml
+++ b/.github/workflows/update-latest-docs.yml
@@ -6,14 +6,15 @@ on:
     branches:
       - "main"
     paths:
-      - "docs/3.8" # This path *must* match the folder name of the latest product release version.
+      - docs/en-us/3.8/** # This path *must* match the folder name of the latest product release version. Be sure to update the number when a new version is released.
+      - docs/ja-jp/3.8/** # This path *must* match the folder name of the latest product release version. Be sure to update the number when a new version is released.
   # The following `workflow_dispatch` lines are for scheduling this workflow to reduce GitHub actions. We might want to consider scheduling docs to sync to the docs site repos in the future if we use too many action minutes in our monthly GitHub quota.
-  # workflow_dispatch:
+  workflow_dispatch:
   # schedule:
   #   - cron: '0 1 * * 1,4' # Run at 1:00 AM Universal Time Coordinated (UTC) / 10:00 AM Japan Standard Time (JST) on Mondays and Thursdays.
 
 jobs:
-  update-latest-version-of-docs:
+  update-latest-version-of-docs-en-us:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,10 +24,29 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
         with:
-          source_file: "docs/3.8/" # This path *must* match the folder name of the latest version.
+          source_file: "docs/3.8/" # This path *must* match the folder name of the latest version. Be sure to update the number when a new version is released.
           destination_repo: "scalar-labs/docs-scalardl" # Target repo
           destination_folder: "docs/latest/" # Folder to sync to
-          destination_branch_create: "scalardl/update-docs-latest"
+          destination_branch_create: "scalardl/update-docs-latest-en-us"
+          user_name: "josh-wong"
+          user_email: "joshua.wong@scalar-labs.com"
+          commit_message: "AUTO: Update the latest version of docs"
+          use_rsync: rsync -avh
+
+  update-latest-version-of-docs-ja-jp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update the `latest` folder to include the same content as the latest version of docs
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.SYNC_DOCS_PAT }}
+        with:
+          source_file: "docs/3.8/" # This path *must* match the folder name of the latest version. Be sure to update the number when a new version is released.
+          destination_repo: "scalar-labs/docs-scalardl" # Target repo
+          destination_folder: "docs/ja-jp/latest/" # Folder to sync to
+          destination_branch_create: "scalardl/update-docs-latest-ja-jp"
           user_name: "josh-wong"
           user_email: "joshua.wong@scalar-labs.com"
           commit_message: "AUTO: Update the latest version of docs"


### PR DESCRIPTION
> [!CAUTION]
>
> Testing still needs to be done on the contents of this PR since I don't know for sure if it's actually needed. (I'd ran into an issue for one workflow, but other workflows seem to work fine.) 
>
> If this PR is, in fact, needed, we shouldn't merge it until we update the workflow that builds Jekyll; otherwise, the workflow for Jekyll will be built twice. Instead, the workflow for building Jekyll should run after this workflow is completed or if this workflow doesn't need to run.

## Description

This PR re-adds a workflow to update the `docs/latest` folder.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardl/pull/90

## Changes made

- Re-added a workflow to update the `docs/latest` folder with the latest version of docs.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A