### PR TITLE
Add language dropdown menu to select docs in English or Japanese

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -371,6 +371,19 @@ defaults:
       toc: true
       toc_sticky: true
       search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  # 3.4 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.4" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.4-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
   
   # Release notes - Japanese docs
   - scope:

--- a/_config.yml
+++ b/_config.yml
@@ -164,6 +164,21 @@ defaults:
       search: false
       classes: wide # Expands the page to take up space where the TOC would normally be.
 
+  # _home - Do not change the `_home` scope.
+  - scope:
+      path: "_home/ja-jp" # Specifies the name of the folder where the parent product docs home page, error page, and other common pages are located.
+      type: home # Specifies the collection type for the parent product home page.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp"
+      toc: false
+      toc_sticky: false
+      search: false
+      classes: wide # Expands the page to take up space where the TOC would normally be.
+
   ############### Template for versions. When adding a new version (`scope`), copy this template and replace `<VERSION>` with the version number`,  and change `search` for the previous version to `false`. ###############
 
   # # <VERSION>
@@ -286,6 +301,101 @@ defaults:
       share: false # Shows social media buttons to share pages.
       sidebar: # Shows side navigation content from `_data/navigation.yml`.
         nav: "latest" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
+
+  # latest - Japanese docs
+  - scope:
+      path: "docs/ja-jp/latest" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
+  # 3.8 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.8" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false
+  # 3.7 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.7" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.7-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  # 3.6 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.6" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # show the average reading time for the page
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.6-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  # 3.5 - Japanese docs
+  - scope:
+      path: "docs/ja-jp/3.5" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "3.5-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: false # Excludes previous versions from search to reduce noise and search loading time. We should improve this function in the future to allow people to search for versioned docs.
+  
+  # Release notes - Japanese docs
+  - scope:
+      path: "docs/ja-jp/releases" # Specifies the name of the folder where this version of docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
+      toc: true
+      toc_sticky: true
+      search: true
+
+  # Common docs in the `docs` root folder - Japanese docs
+  - scope:
+      path: "docs/ja-jp" # Specifies the name of the folder where the common docs are located.
+      # type: "" # Since this scope uses `collection_dir`, we do not need to specify the type here.
+    values:
+      layout: page # Specifies the type of template used from the "_layouts" folder.
+      read_time: false # Shows the average reading time for pages.
+      share: false # Shows social media buttons to share pages.
+      sidebar: # Shows side navigation content from `_data/navigation.yml`.
+        nav: "latest-ja-jp" # Add the version enclosed within quotation marks. If the docs in the navigation is for the latest version of the product, be sure to set `nav:` to `"latest"`. If the docs in the navigation is for a previous version of the product, be sure to set `nav:` to the product version number (e.g., `"3.8"`). That version number must match the set of docs for that product version in `_data/navigation.yml`.
       toc: true
       toc_sticky: true
       search: false

--- a/_home/ja-jp/404.md
+++ b/_home/ja-jp/404.md
@@ -1,0 +1,12 @@
+---
+excerpt: "申し訳ありませんが、お探しのページは見つかりませんでした。"
+sitemap: false
+permalink: /ja-jp/404.html
+toc: false
+---
+
+# 404 - ページが見つかりません
+
+申し訳ありませんが、お探しのページは見つかりませんでした。
+
+[トップページに戻る](/docs/ja-jp/){: .btn .btn--primary}

--- a/_home/ja-jp/home.md
+++ b/_home/ja-jp/home.md
@@ -1,0 +1,60 @@
+---
+layout: parent-product-home
+permalink: /docs/ja-jp/
+hidden: true
+toc: false
+product_row:
+  - image_path: 
+    alt: ""
+    title: "ScalarDL Auditor の使用を開始する" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "Ledger の同一状態を管理するコンポーネント" # Add a brief product description (approximately 8 words)
+    url: "/docs/ja-jp/latest/getting-started-auditor/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "始めましょう" # This can be any other type of call to action
+  - image_path: 
+    alt: ""
+    title: "ScalarDL 認証ガイド" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "認証の仕組みと使い方を解説" # Add a brief product description (approximately 8 words)
+    url: "/docs/ja-jp/latest/authentication/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "始めましょう" # This can be any other type of call to action
+  - image_path: 
+    alt: ""
+    title: "ScalarDL Schema Loader" # This title will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "ScalarDL のデータベーススキーマを読み込むDockerイメージ" # Add a brief product description (approximately 8 words)
+    url: "/docs/ja-jp/latest/schema-loader/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "始めましょう" # This can be any other type of call to action
+recommended_row:
+  - image_path: /assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "ScalarDL の入門" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "クライアント SDK を使用して簡単なコントラクトを実行する" # Add a brief description about the doc (approximately 8 words)
+    url: "/docs/ja-jp/latest/getting-started/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "もっと詳しく知る" # This can be any other type of call to action
+  - image_path: /assets/images/book-green.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "簡単な銀行口座申請" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "簡単な銀行口座アプリケーションを実行してみる" # Add a brief description about the doc (approximately 8 words)
+    url: "/docs/ja-jp/latest/applications/simple-bank-account/README/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "もっと詳しく知る" # This can be any other type of call to action
+  - image_path: /assets/images/page-blue.svg # Choose the appropriate icon for the doc recommended here: (`book-green.svg`, `cloud-purple.svg`, `page-blue.svg`)
+    alt: ""
+    title: "ScalarDL ベンチマーク ツール" # The title for a recommended doc will appear in the header for the feature item on the home page; space is limited, so keep it short but descriptive; try to keep all feature item titles around the same length
+    excerpt: "ScalarDL のベンチマーク プログラムを実行する" # Add a brief description about the doc (approximately 8 words)
+    url: "/docs/ja-jp/latest/scalardl-benchmarks/README/" # Add a relative URL to the product home page doc that is within this parent product docs site
+    btn_class: "btn--primary"
+    btn_label: "もっと詳しく知る" # This can be any other type of call to action
+---
+
+# ScalarDL ドキュメンテーション
+
+ScalarDL は、トランザクション データベース システム用のスケーラブルで実用的なビザンチン障害検出ミドルウェアです。
+
+{% include product_row %}
+
+## 推奨
+
+{% include recommended_row %}

--- a/_home/ja-jp/index.md
+++ b/_home/ja-jp/index.md
@@ -1,0 +1,6 @@
+---
+title: 
+permalink: /ja-jp/
+redirect_to:
+  - http://scalardl.scalar-labs.com/docs/ja-jp/
+---

--- a/_home/ja-jp/terms.md
+++ b/_home/ja-jp/terms.md
@@ -1,0 +1,8 @@
+---
+permalink: /ja-jp/terms/
+toc: false
+---
+
+# プライバシーポリシー
+
+株式会社スカラーのプライバシーポリシーの詳細については、[株式会社Scalarのプライバシーポリシー](https://www.scalar-labs.com/ja/privacy-policy/)をご覧ください。

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -22,9 +22,15 @@
             <ul class="version-dropdown-content">
               {% for version-children in link.version-children %}
                 <li>
-                  <a href="{{ site.baseurl }}{{ version-children.version-url }}">
-                    <span>{{ version-children.version-title }}</span>
-                  </a>
+                  {% if page.url contains '/docs/ja-jp/' %}
+                    <a href="{{ site.baseurl }}{{ version-children.version-ja-jp-url }}">
+                      <span>{{ version-children.version-ja-jp-title }}</span>
+                    </a>
+                  {% else %}
+                    <a href="{{ site.baseurl }}{{ version-children.version-url }}">
+                      <span>{{ version-children.version-title }}</span>
+                    </a>
+                  {% endif %}
                 </li>
               {% endfor %}
             </ul>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,6 +33,37 @@ permalink: /:collection/:path/
       {% endunless %}
 
       <section class="page__content e-content" itemprop="text">
+        <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
+        <nav id="site-nav" class="language-greedy-nav">
+          <ul class="language-visible-links">
+            {%- for link in site.data.navigation.languages -%}
+            {% assign class = nil %}
+            {% if page.language-url contains link.language-url %}
+            {% assign class = 'active' %}
+            {% endif %}
+            {% if link.language-children %}
+            <li class="language-dropdown {{ class }}">
+              <label for="touch-language"><a data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fas fa-globe fa-lg language-toggle" aria-hidden="true"></i><span class="language-dropdown-text">{% if page.url contains "docs/ja-jp" %}言語{% else %}Language{% endif %}<svg class="language-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-language">
+              <ul class="language-dropdown-content">
+                {% for language-children in link.language-children %}
+                <li>
+                  <a href="{{ page.url | replace: 'docs/ja-jp', 'docs' }}">
+                    <span>{{ language-children.language-title }}</span>
+                  </a>
+                </li>
+                <li>
+                  <a href="{{ page.url | replace: 'docs', 'docs/ja-jp' | replace: 'docs/ja-jp/ja-jp', 'docs/ja-jp' }}">
+                    <span>{{ language-children.language-ja-jp-title }}</span>
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </nav>
         {% if page.toc %}
           <aside class="sidebar__right {% if page.toc_sticky %}sticky{% endif %}">
             <nav class="toc">

--- a/_layouts/parent-product-home.html
+++ b/_layouts/parent-product-home.html
@@ -42,6 +42,37 @@ permalink: /:collection/:path/
           </aside>
         {% endif %}
         {{ content }}
+        <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
+        <nav id="site-nav" class="language-greedy-nav">
+          <ul class="language-visible-links">
+            {%- for link in site.data.navigation.languages -%}
+            {% assign class = nil %}
+            {% if page.language-url contains link.language-url %}
+            {% assign class = 'active' %}
+            {% endif %}
+            {% if link.language-children %}
+            <li class="language-dropdown {{ class }}">
+              <label for="touch-language"><a data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fas fa-globe fa-lg language-toggle" aria-hidden="true"></i><span class="language-dropdown-text">{% if page.url contains "docs/ja-jp" %}言語{% else %}Language{% endif %}<svg class="language-dropdown-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"></path></svg></span></a></label>
+              <input type="checkbox" id="touch-language">
+              <ul class="language-dropdown-content">
+                {% for language-children in link.language-children %}
+                <li>
+                  <a href="{{ page.url | replace: 'docs/ja-jp', 'docs' }}">
+                    <span>{{ language-children.language-title }}</span>
+                  </a>
+                </li>
+                <li>
+                  <a href="{{ page.url | replace: 'docs', 'docs/ja-jp' | replace: 'docs/ja-jp/ja-jp', 'docs/ja-jp' }}">
+                    <span>{{ language-children.language-ja-jp-title }}</span>
+                  </a>
+                </li>
+                {% endfor %}
+              </ul>
+            </li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </nav>
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>
 

--- a/_sass/minimal-mistakes.scss
+++ b/_sass/minimal-mistakes.scss
@@ -30,6 +30,7 @@
 @import "minimal-mistakes/search";
 @import "minimal-mistakes/syntax";
 @import "minimal-mistakes/tabbed-content"; /* Added to support tabbed content (added by josh-wong) */
+@import "minimal-mistakes/language-dropdown"; /* Added to support the language dropdown (added by josh-wong) */
 
 /* Utility classes */
 @import "minimal-mistakes/utilities";

--- a/_sass/minimal-mistakes/_language-dropdown.scss
+++ b/_sass/minimal-mistakes/_language-dropdown.scss
@@ -1,0 +1,181 @@
+  /* Add styles to support the switcher for languages, which are specified in `_layouts/page.html` (added by josh-wong). */
+
+.language-greedy-nav {
+display: inline-block;
+margin: 5px;
+display: -webkit-box;
+display: -ms-flexbox;
+display: flex;
+-webkit-box-align: center;
+-ms-flex-align: center;
+align-items: center;
+min-height: 2.1em;
+/* width: 190px; */
+margin-bottom: 0;
+text-align: right;
+font-size: $type-size-5;
+min-width: 140px;
+position: fixed;
+z-index: 11;
+
+/* Added to hide the language dropdown menu on mobile and narrow screens since it makes the Scalar logo tiny (added by josh-wong). */
+// @media screen and (max-width: $small) {
+//   display: none;
+// }
+
+  a {
+    display: block;
+    padding: 0.5em;
+    color: $background-color;
+    -webkit-transition: none;
+    transition: none;
+
+    &:hover {
+      background-color: mix(#000, $background-color, 10%);
+      color: mix(#000, $text-color, 90%);
+    }
+  }
+}
+
+.language-visible-links {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  position: fixed;
+  top: 95px;
+  right: 25px;
+  /* justify-content: flex-end; */
+  /* min-width: auto; */
+  /* float: inline-end; */
+  /* overflow: hidden; */
+  /* max-width: fit-content; */
+
+  li {
+    -webkit-box-flex: 0;
+    -ms-flex: none;
+    flex: none;
+    /* background-color: $background-color; */
+  }
+
+  a {
+    position: relative;
+    color: $background-color;
+    cursor: pointer;
+    opacity: unset;
+    margin-bottom: -5px;
+
+    &:before {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      height: 0px;
+      background: $primary-color;
+      width: 100%;
+      -webkit-transition: $global-transition;
+      transition: $global-transition;
+      -webkit-transform: scaleX(0) translate3d(0, 0, 0);
+      transform: scaleX(0) translate3d(0, 0, 0); // hide
+    }
+
+    &:hover:before {
+      -webkit-transform: scaleX(1);
+      -ms-transform: scaleX(1);
+      transform: scaleX(1); // reveal
+      background-color: mix(#000, $background-color, 10%);
+    }
+  }
+
+  .language-toggle {
+    color: $language-toggle;
+  }
+
+  .language-dropdown {
+    float: left;
+    /* width: 210px; */
+    min-width: 100%;
+    /* max-width: 75%; */
+    font-weight: 500;
+    vertical-align: middle;
+    cursor: default;
+    background-color: $scalar-light-gray-background-color;
+    color: $text-color;
+
+    li {
+      line-height: 1em;
+    }
+    &:hover {
+      background-color: mix($gray, $background-color, 20%);
+    }
+  }
+
+  .language-dropdown-text {
+    color: $text-color;
+    padding: 0 0 0 8px;
+  }
+
+  .language-dropdown-arrow {
+    width: 20px;
+    vertical-align: middle;
+    color: $text-color;
+  }
+
+  .language-dropdown-content {
+    display: none;
+    position: relative;
+    background-color: $background-color;
+    box-shadow: $box-shadow;
+    z-index: 21;
+    /* border: 1pt solid $border-color; */
+    padding-top: 5px;
+    padding-bottom: 5px;
+
+    li {
+      padding: 0;
+      margin: 0;
+    }
+  }
+
+  .language-dropdown-content a {
+    padding: 0 15px 0 15px;
+    margin: 1px;
+    color: $dark-gray;
+    line-height: 1.6em;
+    margin-bottom: 0;
+  }
+
+  /* Adds support for a clickable language dropdown menu (added by josh-wong) */
+  #touch-language {
+    position: absolute;
+    opacity: 0;
+    height: 0px;
+  }
+
+  #touch-language:checked + .language-dropdown-content {
+    /* min-height: 100%; */
+    display: block;
+    /* margin: 0 0 0 3.5em; */
+  }
+
+  /* The following dropdown method is `hover`, which is the default behavior in Minimal Mistakes theme. Comment this out if we want the dropdown to be clicked on rather than hovered over to access (modified by josh-wong).
+  .language-dropdown:hover .language-dropdown-content {
+    display: block;
+  } */
+
+  .language-dropdown-content a:hover {
+    background-color: $scalar-light-gray-background-color;
+  }
+
+  .language-dropdown-content a:not(:last-child) {
+    border-bottom: none;
+  }
+}
+
+.hidden {
+  display: none;
+}

--- a/_sass/minimal-mistakes/_sidebar.scss
+++ b/_sass/minimal-mistakes/_sidebar.scss
@@ -244,6 +244,8 @@
   
   .sidebar__right {
     margin-bottom: 1em;
+    padding-top: 1.5em; /* Added to give some spacing below the language dropdown menu (added by josh-wong). */
+    padding-bottom: 1.5em; /* Added to give some spacing below the language dropdown menu (added by josh-wong). */
   
     @include breakpoint($large) {
       position: absolute;

--- a/_sass/minimal-mistakes/_variables.scss
+++ b/_sass/minimal-mistakes/_variables.scss
@@ -75,6 +75,7 @@ $border-color: $lighter-gray !default;
 $form-background-color: $lighter-gray !default;
 $footer-background-color: $lighter-gray !default;
 $version-out-of-support-background-color: mix(#000, $background-color, 15%) !default;
+$language-toggle: #3C4143 !default;
 
 /* Scalar colors (added by josh-wong) */
 $scalar-primary-color: #2673BB !default;

--- a/_sass/minimal-mistakes/skins/_dark.scss
+++ b/_sass/minimal-mistakes/skins/_dark.scss
@@ -13,17 +13,17 @@ $gray: #7a8288 !default;
 $dark-gray: #eaeaea !default; /* This color isn't really gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
 $form-background-color: mix(#000, $background-color, 15%) !default;
 $footer-background-color: mix(#000, $background-color, 30%) !default;
-$version-out-of-support-background-color: mix(#000, $background-color, 99%) !default;
+$language-toggle: #E9EAEB !default;
 $lighter-gray: mix(#fff, $gray, 90%) !default;
 $link-color: mix(#fff, #2673BB, 20%) !default;
 $link-color-hover: mix(#fff, $link-color, 50%) !default;
 $link-color-visited: mix(#fff, $link-color, 15%) !default;
-$link-color-visited: mix(#fff, #2673BB, 20%) !default;
 $masthead-link-color: $text-color !default;
 $masthead-link-color-hover: mix(#000, $text-color, 20%) !default;
 $navicon-link-color-hover: mix(#000, $background-color, 30%) !default;
 $scalar-primary-color: #2673BB !default;
 $scalar-light-gray-background-color: #1c1c1c !default; /* This color isn't really light gray and should be refactored. However, doing so would take considerable time, so I'm leaving it as is for now (modified by josh-wong). */
+$version-out-of-support-background-color: mix(#000, $background-color, 99%) !default;
 
 /* syntax highlighting (base16) */
 $base00: #1C1C1C !default;


### PR DESCRIPTION
## Description

This PR adds a language dropdown menu so that visitors can see ScalarDL docs and related docs in either English or Japanese.

## Related issues and/or PRs

N/A

## Changes made

- Added a language dropdown menu and the necessary styles to the heading of the docs site.
  - Included a function to allow switching between the same page in English or in Japanese.
- Updated related side navigation and version navigation elements to support docs in Japanese.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A
