### PR TITLE
Fix issue with titles in Japanese showing "null" in search results

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,14 +23,7 @@ permalink: /:collection/:path/
     {% if page.last_modified_at %}<meta itemprop="dateModified" content="{{ page.last_modified_at | date_to_xmlschema }}">{% endif %}
 
     <div class="page__inner-wrap">
-      {% unless page.header.overlay_color or page.header.overlay_image %}
-        <header>
-          {% if page.title %}<h1 id="page-title" class="page__title p-name" itemprop="headline">
-            <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
-          </h1>{% endif %}
-          {% include page__meta.html %}
-        </header>
-      {% endunless %}
+
 
       <section class="page__content e-content" itemprop="text">
         <!-- Adds support for the language dropdown menu for the languages listed in `_data/navigation.yml`. For some reason, adding this dropdown menu to `_includes.masthead.html` results in broken links, regardless of trying to use a variety of logic in the  Liquid language (added by josh-wong). -->
@@ -72,6 +65,17 @@ permalink: /:collection/:path/
             </nav>
           </aside>
         {% endif %}
+
+        {% unless page.header.overlay_color or page.header.overlay_image %}
+        <header>
+          {% if page.title %}
+          <h1 id="page-title" class="page__title p-name" itemprop="headline">
+            <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>
+          </h1>{% endif %}
+          {% include page__meta.html %}
+        </header>
+        {% endunless %}
+
         {{ content }}
         {% if page.link %}<div><a href="{{ page.link }}" class="btn btn--primary">{{ site.data.ui-text[site.locale].ext_link_label | default: "Direct Link" }}</a></div>{% endif %}
       </section>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -68,6 +68,11 @@ permalink: /:collection/:path/
 
         {% unless page.header.overlay_color or page.header.overlay_image %}
         <header>
+          <!-- This if statement shows that the Japanese content on the page has been machine translated (added by josh-wong). -->
+          {% if page.url contains 'ja-jp' %}
+            {% include common/translation-ja-jp.html %}
+          {% endif %}
+
           {% if page.title %}
           <h1 id="page-title" class="page__title p-name" itemprop="headline">
             <a href="{{ page.url | absolute_url }}" class="u-url" itemprop="url">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</a>


### PR DESCRIPTION
## Description

This PR fixes an issue related to Japanese titles in search results. The banner for showing that a page was machine translated, which uses Liquid syntax, was added directly to the Markdown files. However, this caused search results to show Japanese titles as "null."

To avoid this issue, this PR adds a banner that is displayed at the top of Japanese docs, stating that the contents have been machine translated.

## Related issues and/or PRs

**PRs that remove the banner from individual Markdown files**

- https://github.com/scalar-labs/docs-scalardl/pull/120
- https://github.com/scalar-labs/docs-scalardl/pull/119
- https://github.com/scalar-labs/docs-scalardl/pull/118
- https://github.com/scalar-labs/docs-scalardl/pull/117
- https://github.com/scalar-labs/docs-scalardl/pull/116
- https://github.com/scalar-labs/docs-scalardl/pull/114

## Changes made

- Moved the title of the doc so that the banner could be added above it.
  - Needed to move the header because simply adding the banner to above the heading caused the sidebar where the table of contents is to shift down, leaving a large gap between the bottom of the "Contact us" button and the language dropdown.
- Added the banner above the title and make it appear only on Japanese pages. 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A