### PR TITLE
Add Japanese release notes for ScalarDL 3.9

### DIFF
--- a/docs/ja-jp/releases/release-3.9.md
+++ b/docs/ja-jp/releases/release-3.9.md
@@ -1,0 +1,125 @@
+# ScalarDL 3.9 リリースノート
+
+このページには、ScalarDL 3.9 のリリース ノートのリストが含まれています。
+
+## v3.9.0
+
+**発売日：** 2024 年 4 月 5 日
+
+### まとめ
+
+このリリースには、使いやすさを向上させるためにすべての ScalarDL 管理コマンドを統合する単一のトップレベル コマンド「scalardl」の導入や、開発者が任意のプログラミング言語を使用して ScalarDL アプリケーションを作成できるようにするゲートウェイ機能など、いくつかの機能強化が含まれています。 このリリースには多くの改善とバグ修正も含まれています。 詳しい変更点は以下をご覧ください。
+
+### 機能強化
+
+- 使いやすさを向上させるために「scalardl」コマンドを追加しました。
+- ScalarDL Gateway を追加しました。
+- ライセンスチェックメカニズムを追加しました。
+- Prometheus エクスポータに TLS サポートを追加しました。
+
+### 改善点
+
+- クライアントとサーバーの gRPC 構成が改善されました。
+- Gatekeeper の動作を改善しました。
+- CI リリースのワークフローが改善されました。
+- CI テストとメンテナンスが改善されました。
+- シャットダウンする前にサーバーを廃止状態に移行させました。
+- 登録時にコントラクトと機能をロードできるようにしました。
+- OpenShift をサポートしました。
+- schema-loader を元に移行しました。
+- 依存するライブラリをアップグレードしました。
+- アクション/チェックアウトを 2 から 4 にバンプします。
+- aws-actions/configure-aws-credentials を 1 から 4 に変更します。
+- spotbugsVersion を 4.7.1 から 4.7.3 に変更しました。
+- slackapi/slack-github-action を 1.23.0 から 1.24.0 にバンプします。
+- junit:junit を 4.12 から 4.13.2 にバンプします。
+- log4jVersion を 2.17.1 から 2.20.0 に変更します。
+- actions/cache を 1.1.2 から 3.3.2 にバンプします。
+- actions/upload-artifact を 1 から 3 にバンプします。
+- docker/login-action を 1 から 3 に変更します。
+- mockitoVersion を 4.6.0 から 4.11.0 にバンプします。
+- aws-actions/amazon-ecr-login を 1 から 2 に変更します。
+- DropwizardMetricsVersion を 4.2.2 から 4.2.20 に変更します。
+- info.picocli:picocli を 4.1.4 から 4.7.5 にバンプします。
+- com.fasterxml.jackson.core:jackson-databind を 2.13.4.2 から 2.15.3 にバンプします。
+- org.apache.cassandra:cassandra-all を 3.11.11 から 3.11.16 にバンプします。
+- prometheusVersion を 0.12.0 から 0.16.0 に変更します。
+- com.google.inject:guice を 5.0.1 から 5.1.0 に変更します。
+- dropwizardMetricsVersion を 4.2.20 から 4.2.21 に変更しました。
+- com.github.spotbugs を 5.0.9 から 5.2.1 にバンプします。
+- org.slf4j:slf4j-api を 1.7.32 から 1.7.36 にバンプします。
+- junitVersion を 5.10.0 から 5.10.1 に変更します。
+- log4jVersion を 2.20.0 から 2.21.1 に変更します。
+- com.github.everit-org.json-schema:org.everit.json.schema を 1.14.2 から 1.14.3 にバンプします。
+- DropwizardMetricsVersion を 4.2.21 から 4.2.22 に変更します。
+- org.apache.commons:commons-text を 1.10.0 から 1.11.0 にバンプします。
+- org.eclipse.jetty:jetty-servlet を 9.4.43.v20210629 から 9.4.53.v20231009 にバンプします。
+- com.google.protobuf を 0.8.17 から 0.9.4 に変更します。
+- com.github.spotbugs を 5.2.1 から 5.2.3 にバンプします。
+- org.assertj:assertj-core を 3.9.1 から 3.24.2 にバンプします。
+- org.junit.platform:junit-platform-console を 1.10.0 から 1.10.1 にバンプします。
+- com.google.guava:guava を 32.1.2-jre から 32.1.3-jre にバンプします。
+- spotbugsVersion を 4.7.3 から 4.8.1 に変更しました。
+- log4jVersion を 2.21.1 から 2.22.0 に変更します。
+- com.fasterxml.jackson.core:jackson-databind を 2.15.3 から 2.16.0 にバンプします。
+- com.google.protobuf:protoc を 3.24.4 から 3.25.1 に変更します。
+- com.github.spotbugs を 5.2.3 から 5.2.4 にアップグレードします。
+- spotbugsVersion を 4.8.1 から 4.8.2 に変更しました。
+- actions/setup-java を 3 から 4 に変更します。
+- com.github.spotbugs を 5.2.4 から 5.2.5 に変更します。
+- DropwizardMetricsVersion を 4.2.22 から 4.2.23 に変更します。
+- actions/upload-artifact を 3 から 4 に変更します。
+- SpotbugsVersion を 4.8.2 から 4.8.3 に変更しました。
+- com.github.everit-org.json-schema:org.everit.json.schema を 1.14.3 から 1.14.4 にバンプします。
+- com.fasterxml.jackson.core:jackson-databind を 2.16.0 から 2.16.1 にバンプします。
+- scalarDbVersion を 3.10.1 から 3.10.2 に変更します。
+- scalarDbVersion を 3.10.2 から 3.11.0 に変更します。
+- log4jVersion を 2.22.0 から 2.22.1 に変更します。
+- org.assertj:assertj-core を 3.24.2 から 3.25.1 に変更します。
+- com.google.protobuf:protoc を 3.25.1 から 3.25.2 にバンプします。
+- DropwizardMetricsVersion を 4.2.23 から 4.2.24 に変更します。
+- actions/cache を 3 から 4 にバンプします。
+- gradle/gradle-build-action を 2 から 3 に変更します。
+-slackapi/slack-github-action を 1.24.0 から 1.25.0 にバンプします。
+- DropwizardMetricsVersion を 4.2.24 から 4.2.25 に変更します。
+- org.assertj:assertj-core を 3.25.1 から 3.25.2 にバンプします。
+- org.junit.platform:junit-platform-console を 1.10.1 から 1.10.2 にバンプします。
+- org.assertj:assertj-core を 3.25.2 から 3.25.3 にバンプします。
+- junitVersion を 5.10.1 から 5.10.2 に変更します。
+- scalarDbVersion を 3.11.0 から 3.12.0 に変更します。
+- com.google.protobuf:protoc を 3.25.2 から 3.25.3 に変更します。
+- org.eclipse.jetty:jetty-servlet を 9.4.53.v20231009 から 9.4.54.v20240208 にバンプします。
+- scalarDbVersion を 3.12.0 から 3.12.1 に変更します。
+- log4jVersion を 2.22.1 から 2.23.0 に変更します。
+- log4jVersion を 2.23.0 から 2.23.1 に変更します。
+- com.fasterxml.jackson.core:jackson-databind を 2.16.1 から 2.16.2 にバンプします。
+- com.fasterxml.jackson.core:jackson-databind を 2.16.2 から 2.17.0 にバンプします。
+
+### バグの修正
+
+- AWS メーターのディメンション名を修正しました。
+- AWS Marketplace のレジストリ名を修正しました。
+- 認証情報をログとして出力しないように修正しました。
+- LEDGER_HOST を正しく取得するために getTargetHost() を使用するように修正されました。
+- Dockerfile の busybox バージョンを修正しました。
+- 中間モードを使用する際のバグを修正しました。
+- ThrowableConsumer および ThrowableFunction の gRPC スタブ メソッドの FunctionalInterface のバインドされた引数を修正しました。
+- 「デジタル署名」を受け入れるように AuthenticationMethod を修正しました。
+- spotbugs の問題を修正し、一貫性を保つためにコードをフォーマットしました。
+- 結果をクライアントに返す関数の実行を修正しました。
+・指定したシークレットが既に登録されている場合の不要な警告を修正しました。
+- TLS 関連のコードと構成が正しく動作するように修正されました。
+- gRPC 関連の構成を修正しました。
+- いくつかの構成の問題、特に TLS を使用した Gateway を修正しました。
+- TLS gRPC ヘルス チェックをサポートするために、Gateway Docker イメージで grpc_health_probe を使用するように修正されました。
+- org.everit.json.schema を 1.14.2 にアップグレードしました。 [CVE-2023-5072](https://github.com/advisories/GHSA-4jq9-2xhw-jpx7 "CVE-2023-5072")
+- セキュリティ問題を修正するために grpc-health-probe をアップグレードしました。 [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8 "CVE-2023-39325") [GHSA-m425-mq94-257g](https://github.com /advisories/GHSA-m425-mq94-257g "GHSA-m425-mq94-257g")
+- セキュリティ問題を修正するために基本イメージをアップグレードしました。 [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2023-4911](https://github.com/advisories/GHSA-m77w-6vjw-wh2f "CVE-2023-4911") [CVE-2023-29491](https://github.com/advisories/GHSA-vh2x-5rx6-qqhv "CVE-2023-29491") [CVE-2023-47038](https://github.com/advisories / GHSA-96fh-9q43-rmjh "CVE-2023-47038")
+- org.bouncycastle:bcprov-jdk15on を 1.59 から 1.70 にアップグレードしました。 [CVE-2018-1000180](https://github.com/advisories/GHSA-xqj7-j8j5-f2xr "CVE-2018-1000180") [CVE-2018-1000613](https://github.com/advisories/GHSA-4446-656p-f54g "CVE-2018-1000613") [CVE-2020-28052](https://github.com/advisories/GHSA-73xv-w5gp-frxh "CVE-2020-28052")
+
+### その他
+
+- google-java-format v1.7 のコード形式を改善しました。
+- E2E bash ファイル内の関数名のタイプミスを修正しました。
+- ScalarDB の非推奨コードを削除しました。
+- master (v4.x) での互換性のない変更を元に戻しました。

--- a/docs/ja-jp/releases/release-support-policy.md
+++ b/docs/ja-jp/releases/release-support-policy.md
@@ -22,10 +22,17 @@
   </thead>
   <tbody>
     <tr>
+      <td><a href="/docs/releases/release-3.9#v390">3.9</a></td>
+      <td>2024-04-05</td>
+      <td>-</td>
+      <td>-</td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+    </tr>
+    <tr>
       <td><a href="/docs/releases/release-3.8#v380">3.8</a></td>
       <td>2023-04-19</td>
-      <td>-</td>
-      <td>-</td>
+      <td>2025-04-05</td>
+      <td>2025-10-25</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>

--- a/docs/ja-jp/releases/release-support-policy.md
+++ b/docs/ja-jp/releases/release-support-policy.md
@@ -26,35 +26,35 @@
       <td>2023-04-19</td>
       <td>-</td>
       <td>-</td>
-      <td><a href="https://scalar-labs.com/en/contact">お問い合わせ</a></td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td><a href="/docs/releases/release-3.7#v370">3.7</a></td>
       <td>2022-12-02</td>
       <td>2024-04-18</td>
       <td>2024-10-15</td>
-      <td><a href="https://scalar-labs.com/en/contact">お問い合わせ</a></td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td><a href="/docs/releases/release-3.6#v360">3.6</a></td>
       <td>2022-09-22</td>
       <td>2023-12-02</td>
       <td>2024-05-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">お問い合わせ</a></td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr class="version-out-of-support">
       <td><a href="/docs/releases/release-3.5#v350">3.5</a>*</td>
       <td>2022-08-03</td>
       <td>2023-09-22</td>
       <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">お問い合わせ</a></td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr class="version-out-of-support">
       <td><a href="/docs/releases/release-3.4#v340">3.4</a>*</td>
       <td>2022-02-22</td>
       <td>2023-08-03</td>
       <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">お問い合わせ</a></td>
+      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Description

This PR adds Japanese release notes for ScalarDL 3.9 and updates the Japanese version of the Release Support Policy page.

## Related issues and/or PRs

These changes should have been included in the following PR: 

- https://github.com/scalar-labs/docs-scalardl/pull/163

## Changes made

- Created a Japanese version of the release notes for ScalarDL 3.9.
- Updated the Release Support Policy to include ScalarDL 3.9.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A