### PR TITLE
Update sidebar navigation, putting Kubernetes-related alert docs into their own collapsible section

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -173,7 +173,15 @@ const sidebars = {
               label: 'Monitoring Guides',
               collapsible: true,
               items: [
-                'scalar-kubernetes/alerts/README',
+                {
+                  type: 'category',
+                  label: 'Alerts',
+                  collapsible: true,
+                  items: [
+                    'scalar-kubernetes/alerts/Envoy',
+                    'scalar-kubernetes/alerts/Ledger',
+                  ],
+                },
                 'scalar-kubernetes/K8sMonitorGuide',
                 'scalar-kubernetes/K8sLogCollectionGuide',
               ],

--- a/versioned_sidebars/version-3.4-sidebars.json
+++ b/versioned_sidebars/version-3.4-sidebars.json
@@ -144,7 +144,15 @@
               "label": "Monitoring Guides",
               "collapsible": true,
               "items": [
-                "scalar-kubernetes/alerts/README",
+                {
+                  "type": "category",
+                  "label": "Alerts",
+                  "collapsible": true,
+                  "items": [
+                    "scalar-kubernetes/alerts/Envoy",
+                    "scalar-kubernetes/alerts/Ledger"
+                  ]
+                },
                 "scalar-kubernetes/K8sMonitorGuide",
                 "scalar-kubernetes/K8sLogCollectionGuide"
               ]

--- a/versioned_sidebars/version-3.5-sidebars.json
+++ b/versioned_sidebars/version-3.5-sidebars.json
@@ -144,7 +144,15 @@
               "label": "Monitoring Guides",
               "collapsible": true,
               "items": [
-                "scalar-kubernetes/alerts/README",
+                {
+                  "type": "category",
+                  "label": "Alerts",
+                  "collapsible": true,
+                  "items": [
+                    "scalar-kubernetes/alerts/Envoy",
+                    "scalar-kubernetes/alerts/Ledger"
+                  ]
+                },
                 "scalar-kubernetes/K8sMonitorGuide",
                 "scalar-kubernetes/K8sLogCollectionGuide"
               ]

--- a/versioned_sidebars/version-3.6-sidebars.json
+++ b/versioned_sidebars/version-3.6-sidebars.json
@@ -142,7 +142,15 @@
               "label": "Monitoring Guides",
               "collapsible": true,
               "items": [
-                "scalar-kubernetes/alerts/README",
+                {
+                  "type": "category",
+                  "label": "Alerts",
+                  "collapsible": true,
+                  "items": [
+                    "scalar-kubernetes/alerts/Envoy",
+                    "scalar-kubernetes/alerts/Ledger"
+                  ]
+                },
                 "scalar-kubernetes/K8sMonitorGuide",
                 "scalar-kubernetes/K8sLogCollectionGuide"
               ]

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -152,7 +152,15 @@
               "label": "Monitoring Guides",
               "collapsible": true,
               "items": [
-                "scalar-kubernetes/alerts/README",
+                {
+                  "type": "category",
+                  "label": "Alerts",
+                  "collapsible": true,
+                  "items": [
+                    "scalar-kubernetes/alerts/Envoy",
+                    "scalar-kubernetes/alerts/Ledger"
+                  ]
+                },
                 "scalar-kubernetes/K8sMonitorGuide",
                 "scalar-kubernetes/K8sLogCollectionGuide"
               ]

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -153,7 +153,15 @@
               "label": "Monitoring Guides",
               "collapsible": true,
               "items": [
-                "scalar-kubernetes/alerts/README",
+                {
+                  "type": "category",
+                  "label": "Alerts",
+                  "collapsible": true,
+                  "items": [
+                    "scalar-kubernetes/alerts/Envoy",
+                    "scalar-kubernetes/alerts/Ledger"
+                  ]
+                },
                 "scalar-kubernetes/K8sMonitorGuide",
                 "scalar-kubernetes/K8sLogCollectionGuide"
               ]


### PR DESCRIPTION
## Description

This PR updates the sidebar navigation, putting Kubernetes-related alert docs into their own collapsible section.

## Related issues and/or PRs

N/A

## Changes made

- Put Kubernetes-related alert docs into their own collapsible section.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A