### PR TITLE
Update Assistance Support end date for ScalarDL 3.8

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -32,7 +32,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="../../3.8/releases/release-notes#v380">3.8</a></td>
       <td>2023-04-19</td>
       <td>2025-04-05</td>
-      <td>2025-10-25</td>
+      <td>2025-10-02</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -36,7 +36,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="../../3.8/releases/release-notes#v380">3.8</a></td>
       <td>2023-04-19</td>
       <td>2025-04-05</td>
-      <td>2025-10-25</td>
+      <td>2025-10-02</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
@@ -26,17 +26,10 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </thead>
   <tbody>
     <tr>
-      <td><a href="../../3.9/releases/release-3.9#v390">3.9</a></td>
-      <td>2024-04-05</td>
-      <td>-</td>
-      <td>-</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
-    </tr>
-    <tr>
-      <td><a href="../../3.9/releases/release-3.8#v380">3.8</a></td>
+      <td><a href="../../3.8/releases/release-3.8#v380">3.8</a></td>
       <td>2023-04-19</td>
       <td>2025-04-05</td>
-      <td>2025-10-25</td>
+      <td>2025-10-02</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -25,7 +25,7 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="../../3.8/releases/release-notes#v380">3.8</a></td>
       <td>2023-04-19</td>
       <td>2025-04-05</td>
-      <td>2025-10-25</td>
+      <td>2025-10-02</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
## Description

This PR updates the Assistance Support end date for ScalarDL 3.8 since the date was incorrect.

## Related issues and/or PRs

N/A

## Changes made

- Changed the Assistance Support end date across applicable Release Support Policy doc versions.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A