### PR TITLE
Add "About ScalarDL" category and overview doc to sidebar navigation

### DIFF
--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current.json
@@ -3,6 +3,10 @@
     "message": "3.9",
     "description": "The label for version current"
   },
+  "sidebar.docs.category.About ScalarDL": {
+    "message": "ScalarDL について",
+    "description": "The label for category About ScalarDL in sidebar docs"
+  },
   "sidebar.docs.category.Getting Started": {
     "message": "始めましょう",
     "description": "The label for category Getting Started in sidebar docs"

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7.json
@@ -3,6 +3,10 @@
     "message": "3.7",
     "description": "The label for version 3.7"
   },
+  "sidebar.docs.category.About ScalarDL": {
+    "message": "ScalarDL について",
+    "description": "The label for category About ScalarDL in sidebar docs"
+  },
   "sidebar.docs.category.Getting Started": {
     "message": "始めましょう",
     "description": "The label for category Getting Started in sidebar docs"

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
@@ -3,6 +3,10 @@
     "message": "3.8",
     "description": "The label for version 3.8"
   },
+  "sidebar.docs.category.About ScalarDL": {
+    "message": "ScalarDL について",
+    "description": "The label for category About ScalarDL in sidebar docs"
+  },
   "sidebar.docs.category.Getting Started": {
     "message": "始めましょう",
     "description": "The label for category Getting Started in sidebar docs"

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,6 +30,8 @@ const sidebars = {
       'collapsible': true,
       'items': [
         'overview',
+        'implementation',
+        'design',
       ]
     },
     {
@@ -217,9 +219,7 @@ const sidebars = {
       label: 'Reference',
       collapsible: true,
       items: [
-        'design',
         'compatibility',
-        'implementation',
         'scalardl-benchmarks/README',
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -25,6 +25,14 @@ const sidebars = {
       id: 'index',
     },
     {
+      'type': 'category',
+      'label': 'About ScalarDL',
+      'collapsible': true,
+      'items': [
+        'overview',
+      ]
+    },
+    {
       type: 'category',
       label: 'Getting Started',
       collapsible: true,

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -11,6 +11,8 @@
       "collapsible": true,
       "items": [
         "overview",
+        "implementation",
+        "design"
       ]
     },
     {
@@ -196,9 +198,7 @@
       "label": "Reference",
       "collapsible": true,
       "items": [
-        "design",
         "compatibility",
-        "implementation",
         "scalardl-benchmarks/README"
       ]
     },

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -7,6 +7,14 @@
     },
     {
       "type": "category",
+      "label": "About ScalarDL",
+      "collapsible": true,
+      "items": [
+        "overview",
+      ]
+    },
+    {
+      "type": "category",
       "label": "Getting Started",
       "collapsible": true,
       "items": [

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -7,6 +7,14 @@
     },
     {
       "type": "category",
+      "label": "About ScalarDL",
+      "collapsible": true,
+      "items": [
+        "overview",
+      ]
+    },
+    {
+      "type": "category",
       "label": "Getting Started",
       "collapsible": true,
       "items": [

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -11,6 +11,8 @@
       "collapsible": true,
       "items": [
         "overview",
+        "implementation",
+        "design"
       ]
     },
     {
@@ -197,9 +199,7 @@
       "label": "Reference",
       "collapsible": true,
       "items": [
-        "design",
         "compatibility",
-        "implementation",
         "scalardl-benchmarks/README"
       ]
     },


### PR DESCRIPTION
## Description

This PR adds the ScalarDL overview doc to the new `About ScalarDL` category for versions that are under Maintenance Support and re-categorizes some docs in the `Reference` category to the `About ScalarDL` category.

## Related issues and/or PRs

PRs for the overview docs in English and Japanese:

- https://github.com/scalar-labs/docs-scalardl/pull/227
- https://github.com/scalar-labs/docs-scalardl/pull/228
- https://github.com/scalar-labs/docs-scalardl/pull/229
- https://github.com/scalar-labs/docs-scalardl/pull/230
- https://github.com/scalar-labs/docs-scalardl/pull/231
- https://github.com/scalar-labs/docs-scalardl/pull/232

## Changes made

- Created a new category named `About ScalarDL` in the sidebar navigation.
- Added the ScalarDL overview doc to the new `About ScalarDL` category for versions that are under Maintenance Support.
- Moved the design and implementation docs that were in the `Reference` category to the `About ScalarDL` category.
- Added `ScalarDL について` category to the Japanese sidebar navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A