### PR TITLE
Enable Algolia DocSearch for search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,14 +145,14 @@ const config = {
         },
       },
     ],
-    [
-      require.resolve("docusaurus-lunr-search"),
-      {
-        enableHighlight: true,
-        languages: ['en', 'ja'], // language codes
-        includeRoutes: ['/docs/latest/**', '/ja-jp/docs/latest/**'],
-      },
-    ],
+    // [
+    //   require.resolve("docusaurus-lunr-search"),
+    //   {
+    //     enableHighlight: true,
+    //     languages: ['en', 'ja'], // language codes
+    //     includeRoutes: ['/docs/latest/**', '/ja-jp/docs/latest/**'],
+    //   },
+    // ],
   ],
 
   themeConfig:
@@ -180,35 +180,35 @@ const config = {
           },
         ],
       },
-      // algolia: {
-      //   // The application ID provided by Algolia
-      //   appId: 'CY5H1F29T8',
+      algolia: {
+        // The application ID provided by Algolia
+        appId: 'CY5H1F29T8',
 
-      //   // Public API key: it is safe to commit it
-      //   apiKey: 'fe68b2de652056b08dcdf6439691141b',
+        // Public API key: it is safe to commit it
+        apiKey: 'fe68b2de652056b08dcdf6439691141b',
 
-      //   indexName: 'scalardl-scalar-labs',
+        indexName: 'scalardl-scalar-labs',
 
-      //   // Optional: see doc section below
-      //   contextualSearch: true,
+        // Optional: see doc section below
+        contextualSearch: true,
 
-      //   // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-      //   // externalUrlRegex: 'external\\.com|domain\\.com',
+        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+        // externalUrlRegex: 'external\\.com|domain\\.com',
 
-      //   // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-      //   // replaceSearchResultPathname: {
-      //   //   from: '/docs/', // or as RegExp: /\/docs\//
-      //   //   to: '/',
-      //   // },
+        // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
+        // replaceSearchResultPathname: {
+        //   from: '/docs/', // or as RegExp: /\/docs\//
+        //   to: '/',
+        // },
 
-      //   // Optional: Algolia search parameters
-      //   // searchParameters: {},
+        // Optional: Algolia search parameters
+        // searchParameters: {},
 
-      //   // Optional: path for search page that enabled by default (`false` to disable it)
-      //   searchPagePath: 'search',
+        // Optional: path for search page that enabled by default (`false` to disable it)
+        searchPagePath: 'search',
 
-      //   //... other Algolia params
-      // },
+        //... other Algolia params
+      },
       footer: {
         style: 'dark',
         links: [


### PR DESCRIPTION
## Description

This PR enables [Algolia DocSearch](https://docsearch.algolia.com/) and disables the Lunr search plugin, [docusaurus-lunr-search](https://github.com/praveenn77/docusaurus-lunr-search). 

We initially needed to use Lunr as our search solution because Algolia DocSearch wasn't showing results. The reason why results weren't being displayed was because the crawler template that Algolia provided didn't include all the necessary [attributes and settings specific to Docusaurus v3](https://docsearch.algolia.com/docs/templates#docusaurus-v3-template). After adding those attributes and settings in the Algolia Crawler, I confirmed that search works as expected locally.

Also, rather than removing the Lunr search plugin, [docusaurus-lunr-search](https://github.com/praveenn77/docusaurus-lunr-search), I've commented it out so that we can quickly switch back to that search solution later if necessary.

## Related issues and/or PRs

> If this PR addresses or references any issues and/or other PRs, list them here.

## Changes made

- In the Docusaurus configuration file:
  - Uncommented the configurations for Algolia DocSearch.
  - Commented out the Lunr search plugin ([docusaurus-lunr-search](https://github.com/praveenn77/docusaurus-lunr-search).
- In the Algolia Crawler web UI:
  - Added the necessary attributes and settings, according to the [Docusaurus v3 template for Algolia DocSearch](https://docsearch.algolia.com/docs/templates#docusaurus-v3-template).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A