### PR TITLE
Add announcement bar template to Docusaurus configuration file

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -291,6 +291,14 @@ const config = {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
       },
+      // announcementBar: {
+      //   id: 'new_version',
+      //   content:
+      //     '<b>ScalarDL X.X is now available!🥳 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.<b>',
+      //   backgroundColor: '#2673BB',
+      //   textColor: '#FFFFFF',
+      //   isCloseable: false,
+      // },
     }),
 };
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,3 +36,9 @@
 .markdown h1:first-child {
   --ifm-h1-font-size: 2.25rem;
 }
+
+/* Announcement Bar */
+div[class^='announcementBar'] {
+  font-size: 1.1rem;
+  padding: 20px 0;
+}


### PR DESCRIPTION
## Description

This PR adds a template for the announcement bar so that we can quickly add an announcement to the docs site. In addition, the default font size is a little small and the top and bottom padding is a little narrow, so this PR adds custom styles to increase both styles. 

For details about the announcement bar in Docusaurus, see [Announcement bar](https://docusaurus.io/docs/api/themes/configuration#announcement-bar).

## Related issues and/or PRs

N/A

## Changes made

- Added an announcement bar template to the Docusaurus configuration file.
- Added custom styles for the announcement bar.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation (`_data/navigation.yml`) as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A