### PR TITLE
Remove Jekyll-specific language from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 
 > The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.
 
-- [ ] I have updated the side navigation (`_data/navigation.yml`) as necessary.
+- [ ] I have updated the side navigation as necessary.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have updated the documentation to reflect the changes.
 - [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).


### PR DESCRIPTION
## Description

This PR removes Jekyll-specific language from the generic PR template. Since we've moved to Docusaurus, Jekyll-related wording should be removed.

## Related issues and/or PRs

N/A

## Changes made

- Removed Jekyll-specific wording from the PR template.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A