### PR TITLE
Make unsupported versions on Release Support Policy pages easier to see

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -50,18 +50,20 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -54,18 +54,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.4/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.4/releases/release-support-policy.mdx
@@ -26,11 +26,13 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.5/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.5/releases/release-support-policy.mdx
@@ -26,18 +26,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.6/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.6/releases/release-support-policy.mdx
@@ -33,18 +33,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
@@ -40,18 +40,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
@@ -47,18 +47,20 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,12 @@
   --ifm-h1-font-size: 2.25rem;
 }
 
+.version-out-of-support, .version-out-of-support a {
+  background-color: #9CA3AF;
+  color: #1c1e21;
+  opacity: 85%;
+}
+
 /* Announcement Bar */
 div[class^='announcementBar'] {
   font-size: 1.1rem;

--- a/versioned_docs/version-3.4/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.4/releases/release-support-policy.mdx
@@ -22,11 +22,13 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/versioned_docs/version-3.5/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.5/releases/release-support-policy.mdx
@@ -22,18 +22,20 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/versioned_docs/version-3.6/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.6/releases/release-support-policy.mdx
@@ -29,18 +29,20 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/versioned_docs/version-3.7/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.7/releases/release-support-policy.mdx
@@ -36,18 +36,20 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -43,18 +43,20 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a></td>
-      <td>2022-08-03</td>
-      <td>2023-09-22</td>
-      <td>2024-03-20</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support">2022-08-03</td>
+      <td class="version-out-of-support">2023-09-22</td>
+      <td class="version-out-of-support">2024-03-20</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a></td>
-      <td>2022-02-22</td>
-      <td>2023-08-03</td>
-      <td>2024-01-30</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support">2022-02-22</td>
+      <td class="version-out-of-support">2023-08-03</td>
+      <td class="version-out-of-support">2024-01-30</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
   </tbody>
 </table>
+
+&#42; This product version is no longer supported under Maintenance Support or Assistance Support.


### PR DESCRIPTION
## Description

This PR makes unsupported versions in the table on the Release Support Policy pages easier to see. Being able to quickly see which versions are no longer supported is more user friendly than having to skim all versions and determine if the version is no longer supported.

## Related issues and/or PRs

N/A

## Changes made

- Added a custom style to change the background, font color, and opacity of unsupported versions.
- Added the custom style to each cell of the unsupported versions in the table across versions and languages.
- Added an asterisk with a note to the end of the Release Support Policy pages.

> [!NOTE]
>
> I tried adding the custom style to the table row (`tr`), but the default style for tables in Docusaurus overrides styles added in the **custom.css** file. Basically, every other table has a gray background, but that gray background can't be overridden by a custom style. Because of that, I applied the custom style to each cell, which allows us to change the background color of the row. 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A