### PR TITLE
Fix versioning bug that occurs when a minor version with multiple digits (`X.XX`) exists in Docusaurus

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,38 +65,38 @@ const config = {
             versions: {
               // The following is a template for adding a new version to the dropdown menu. Copy this version template when adding a new version to the dropdown menu but don't delete it.
               /*
-              current: {
+              current: { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '<VERSION_NUMBER>',
-                path: 'latest',
+                path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
               },
               */
-              current: {
+              current: { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.9',
-                path: 'latest',
+                path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
               },
-              3.8: { // Change this to the version number when a new version is released.
+              "3.8": {
                 label: '3.8',
-                path: '3.8', // Change this to the version number when a new version is released.
+                path: '3.8',
                 banner: 'none',
               },
-              3.7: {
+              "3.7": {
                 label: '3.7',
                 path: '3.7',
                 banner: 'none',
               },
-              3.6: {
+              "3.6": {
                 label: '3.6',
                 path: '3.6',
                 banner: 'none',
               },
-              3.5: {
+              "3.5": {
                 label: '3.5 (unsupported)',
                 path: '3.5',
                 banner: 'unmaintained',
               },
-              3.4: {
+              "3.4": {
                 label: '3.4 (unsupported)',
                 path: '3.4',
                 banner: 'unmaintained',


### PR DESCRIPTION
## Description

This PR fixes a bug that occurs when a minor version with multiple digits (`X.XX`) exists in Docusaurus.

Docusaurus throws an error and cannot build the site when a minor version reaches `X.XX`. In our case, the error displayed is `unknown version (3.1) found` when trying to build a site that has version 3.10. To get around this when we release an `X.XX` version in the future, we need to add double quotation marks around version numbers.

> [!NOTE]
>
> I discovered this when migrating the ScalarDB docs site from Jekyll to Docusaurus. Version 3.10 exists for ScalarDB, so trying to build the site would result in the `unknown version (3.1) found` error occurring.

## Related issues and/or PRs

N/A

## Changes made

- Added quotation marks to the version numbers in the Docusaurus configuration file.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A