### PR TITLE
Clarify lack of support end dates for latest release in Release Support Policy

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -24,8 +24,8 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/docs/latest/releases/release-notes#v390">3.9</a></td>
       <td>2024-04-05</td>
-      <td>-</td>
-      <td>-</td>
+      <td>TBD*</td>
+      <td>TBD*</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
@@ -50,14 +50,14 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
       <td class="version-out-of-support">2022-08-03</td>
       <td class="version-out-of-support">2023-09-22</td>
       <td class="version-out-of-support">2024-03-20</td>
       <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
       <td class="version-out-of-support">2022-02-22</td>
       <td class="version-out-of-support">2023-08-03</td>
       <td class="version-out-of-support">2024-01-30</td>
@@ -66,4 +66,5 @@ This page describes Scalar's support policy for major and minor version releases
   </tbody>
 </table>
 
-&#42; This product version is no longer supported under Maintenance Support or Assistance Support.
+\* "TBD" will be replaced with a date after the next minor version is released.<br />
+\*\* This product version is no longer supported under Maintenance Support or Assistance Support.

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -28,8 +28,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/latest/releases/release-notes#v390">3.9</a></td>
       <td>2024-04-05</td>
-      <td>-</td>
-      <td>-</td>
+      <td>TBD*</td>
+      <td>TBD*</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
@@ -54,14 +54,14 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
       <td class="version-out-of-support">2022-08-03</td>
       <td class="version-out-of-support">2023-09-22</td>
       <td class="version-out-of-support">2024-03-20</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
       <td class="version-out-of-support">2022-02-22</td>
       <td class="version-out-of-support">2023-08-03</td>
       <td class="version-out-of-support">2024-01-30</td>
@@ -70,4 +70,5 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </tbody>
 </table>
 
-&#42; この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。
+\* 「TBD」は、次のマイナー バージョンがリリースされた後の日付に置き換えられます。<br/>
+\*\* この製品バージョンは、メンテナンス サポートまたはアシスタンス サポートではサポートされなくなりました。


### PR DESCRIPTION
## Description

This PR aims to clarify the lack of end dates for Maintenance Support and Assistance Support for the latest version of ScalarDL in the Release Support Policy. Since we don't add the dates until the next version is released, we should clarify why there aren't dates listed rather than marking the cells as `-`, which is unclear.

## Related issues and/or PRs

N/A

## Changes made

- Replaced `-` with `TBD*` to clarify why the latest version doesn't have dates listed in the Maintenance Support and Assistance Support cells.
- Added a note below the table that describes what `TBD` means.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A