### PR TITLE
Revert "Update Docusaurus from `3.2.1` to `3.4.0`"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "docs-scalardl",
       "version": "1.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.4.0",
-        "@docusaurus/plugin-client-redirects": "^3.4.0",
-        "@docusaurus/plugin-content-docs": "^3.4.0",
-        "@docusaurus/plugin-google-gtag": "^3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "^3.4.0",
-        "@docusaurus/preset-classic": "^3.4.0",
-        "@docusaurus/theme-mermaid": "^3.4.0",
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/plugin-client-redirects": "^3.2.1",
+        "@docusaurus/plugin-content-docs": "^3.2.1",
+        "@docusaurus/plugin-google-gtag": "^3.2.1",
+        "@docusaurus/plugin-google-tag-manager": "^3.2.1",
+        "@docusaurus/preset-classic": "3.2.1",
+        "@docusaurus/theme-mermaid": "^3.2.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "docusaurus-lunr-search": "^3.3.2",
@@ -24,8 +24,8 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.4.0",
-        "@docusaurus/types": "^3.4.0"
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/types": "3.2.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -490,9 +490,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
-      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.0.tgz",
+      "integrity": "sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1582,11 +1582,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.7.tgz",
-      "integrity": "sha512-7LidzZfUXyfZ8/buRW6qIIHBY8wAZ1OrY9c/wTr8YhZ6vMPo+Uc/CVFLYY1spZrEQlD4w5u8wjqk5NQ3OVqQKA==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.24.1.tgz",
+      "integrity": "sha512-QXp1U9x0R7tkiGB0FOk8o74jhnap0FlZ5gNkRIWdG3eP+SvMFg118e1zaWewDzgABb106QSKpVsD3Wgd8t6ifA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2144,9 +2144,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
-      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.2.1.tgz",
+      "integrity": "sha512-ZeMAqNvy0eBv2dThEeMuNzzuu+4thqMQakhxsgT5s02A8LqRcdkg+rbcnuNqUIpekQ4GRx3+M5nj0ODJhBXo9w==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2158,12 +2158,14 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/cssnano-preset": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
+        "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2177,8 +2179,8 @@
         "copy-webpack-plugin": "^11.0.0",
         "core-js": "^3.31.1",
         "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
+        "css-minimizer-webpack-plugin": "^4.2.2",
+        "cssnano": "^5.1.15",
         "del": "^6.1.1",
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
@@ -2198,7 +2200,7 @@
         "prompts": "^2.4.2",
         "react-dev-utils": "^12.0.1",
         "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
         "react-router": "^5.3.4",
         "react-router-config": "^5.1.1",
@@ -2228,26 +2230,14 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/react-loadable": {
-      "name": "@docusaurus/react-loadable",
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
-      "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
-      "dependencies": {
-        "@types/react": "*"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
-      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.1.tgz",
+      "integrity": "sha512-wTL9KuSSbMJjKrfu385HZEzAoamUsbKqwscAQByZw4k6Ja/RWpqgVvt/CbAC+aYEH6inLzOt+MjuRwMOrD3VBA==",
       "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
+        "cssnano-preset-advanced": "^5.3.10",
+        "postcss": "^8.4.26",
+        "postcss-sort-media-queries": "^4.4.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2255,9 +2245,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
-      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.2.1.tgz",
+      "integrity": "sha512-0voOKJCn9RaM3np6soqEfo7SsVvf2C+CDTWhW+H/1AyBhybASpExtDEz+7ECck9TwPzFQ5tt+I3zVugUJbJWDg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2267,13 +2257,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
-      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.2.1.tgz",
+      "integrity": "sha512-Fs8tXhXKZjNkdGaOy1xSLXSwfjCMT73J3Zfrju2U16uGedRFRjgK0ojpK5tiC7TnunsL3tOFgp1BSMBRflX9gw==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2305,45 +2295,35 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
-      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.0.tgz",
+      "integrity": "sha512-jRSp9YkvBwwNz6Xgy0RJPsnie+Ebb//gy7GdbkJ2pW2gvvlYKGib2+jSF0pfIzvyZLulfCynS1KQdvDKdSl8zQ==",
+      "dev": true,
       "dependencies": {
-        "@docusaurus/types": "3.4.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "3.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
       },
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
       }
     },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/react-loadable": {
-      "name": "@docusaurus/react-loadable",
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
-      "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
-      "dependencies": {
-        "@types/react": "*"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.4.0.tgz",
-      "integrity": "sha512-Pr8kyh/+OsmYCvdZhc60jy/FnrY6flD2TEAhl4rJxeVFxnvvRgEhoaIVX8q9MuJmaQoh6frPk94pjs7/6YgBDQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.2.1.tgz",
+      "integrity": "sha512-GgzuqwbqNQSP5s/ouUrOQFuHI8m4Rn8a5CHuWkwpqj+5lbQMsABcvsoiWjrH9M00CzN48q+slSbJy7rtHjn7zg==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2358,17 +2338,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
-      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.1.tgz",
+      "integrity": "sha512-lOx0JfhlGZoZu6pEJfeEpSISZR5dQbJGGvb42IP13G5YThNHhG9R9uoWuo4IOimPqBC7sHThdLA3VLevk61Fsw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2388,19 +2368,39 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
-      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
+    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.1.tgz",
+      "integrity": "sha512-GHe5b/lCskAR8QVbfWAfPAApvRZgqk7FN3sOHgjCtjzQACZxkHmq6QqyqZ8Jp45V7lVck4wt2Xw2IzBJ7Cz3bA==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/module-type-aliases": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2418,16 +2418,55 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
-      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz",
+      "integrity": "sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "3.2.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.1.tgz",
+      "integrity": "sha512-TOqVfMVTAHqWNEGM94Drz+PUpHDbwFy6ucHFgyTx9zJY7wPNSG5EN+rd/mU7OvAi26qpOn2o9xTdUmb28QLjEQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2440,14 +2479,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
-      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
+    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.2.1.tgz",
+      "integrity": "sha512-AMKq8NuUKf2sRpN1m/sIbqbRbnmk+rSA+8mNU1LNxEl9BW9F/Gng8m9HKlzeyMPrf5XidzS1jqkuTLDJ6KIrFw==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2460,14 +2519,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
-      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
+    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.1.tgz",
+      "integrity": "sha512-/rJ+9u+Px0eTCiF4TNcNtj3kHf8cp6K1HCwOTdbsSlz6Xn21syZYcy+f1VM9wF6HrvUkXUcbM5TDCvg2IRL6bQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2478,14 +2557,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
-      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
+    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.1.tgz",
+      "integrity": "sha512-XtuJnlMvYfppeVdUyKiDIJAa/gTJKCQU92z8CLZZ9ibJdgVjFOLS10s0hIC0eL5z0U2u2loJz2rZ63HOkNHbBA==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2497,14 +2596,34 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
-      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
+    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.1.tgz",
+      "integrity": "sha512-wiS/kE0Ny5pnjTxVCs8ljRnkL1RVMj59t6jmSsgEX7piDOoaXSMIUaoIt9ogS/v132uO0xEsxHstkRUZHQyPcQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2515,17 +2634,37 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
-      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
+    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.1.tgz",
+      "integrity": "sha512-uWZ7AxzdeaQSTCwD2yZtOiEm9zyKU+wqCmi/Sf25kQQqqFSBZUStXfaQ8OHP9cecnw893ZpZ811rPhB/wfujJw==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2538,24 +2677,44 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
-      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/plugin-debug": "3.4.0",
-        "@docusaurus/plugin-google-analytics": "3.4.0",
-        "@docusaurus/plugin-google-gtag": "3.4.0",
-        "@docusaurus/plugin-google-tag-manager": "3.4.0",
-        "@docusaurus/plugin-sitemap": "3.4.0",
-        "@docusaurus/theme-classic": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-search-algolia": "3.4.0",
-        "@docusaurus/types": "3.4.0"
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.2.1.tgz",
+      "integrity": "sha512-E3OHSmttpEBcSMhfPBq3EJMBxZBM01W1rnaCUTXy9EHvkmB5AwgTfW1PwGAybPAX579ntE03R+2zmXdizWfKnQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/plugin-content-blog": "3.2.1",
+        "@docusaurus/plugin-content-docs": "3.2.1",
+        "@docusaurus/plugin-content-pages": "3.2.1",
+        "@docusaurus/plugin-debug": "3.2.1",
+        "@docusaurus/plugin-google-analytics": "3.2.1",
+        "@docusaurus/plugin-google-gtag": "3.2.1",
+        "@docusaurus/plugin-google-tag-manager": "3.2.1",
+        "@docusaurus/plugin-sitemap": "3.2.1",
+        "@docusaurus/theme-classic": "3.2.1",
+        "@docusaurus/theme-common": "3.2.1",
+        "@docusaurus/theme-search-algolia": "3.2.1",
+        "@docusaurus/types": "3.2.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2565,23 +2724,55 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
-      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/react-loadable": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.2.1.tgz",
+      "integrity": "sha512-+vSbnQyoWjc6vRZi4vJO2dBU02wqzynsai15KK+FANZudrYaBHtkbLZAQhgmxzBGVpxzi87gRohlMm+5D8f4tA==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/module-type-aliases": "3.2.1",
+        "@docusaurus/plugin-content-blog": "3.2.1",
+        "@docusaurus/plugin-content-docs": "3.2.1",
+        "@docusaurus/plugin-content-pages": "3.2.1",
+        "@docusaurus/theme-common": "3.2.1",
+        "@docusaurus/theme-translations": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2604,18 +2795,57 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
-      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz",
+      "integrity": "sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/plugin-content-blog": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/plugin-content-pages": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "3.2.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.2.1.tgz",
+      "integrity": "sha512-d+adiD7L9xv6EvfaAwUqdKf4orsM3jqgeqAM+HAjgL/Ux0GkVVnfKr+tsoe+4ow4rHe6NUt+nkkW8/K8dKdilA==",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "3.2.1",
+        "@docusaurus/module-type-aliases": "3.2.1",
+        "@docusaurus/plugin-content-blog": "3.2.1",
+        "@docusaurus/plugin-content-docs": "3.2.1",
+        "@docusaurus/plugin-content-pages": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2633,16 +2863,55 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.4.0.tgz",
-      "integrity": "sha512-3w5QW0HEZ2O6x2w6lU3ZvOe1gNXP2HIoKDMJBil1VmLBc9PmpAG17VmfhI/p3L2etNmOiVs5GgniUqvn8AFEGQ==",
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz",
+      "integrity": "sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==",
       "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/module-type-aliases": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "3.2.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.1.tgz",
+      "integrity": "sha512-l1FzUPgDUor/25XeJDeO22dttmzB0QnmAbF2qKjDz3ENa9vlD5rd5r0NrItZIe8y7qoa+OOxkl5lLBKBxBVbLg==",
+      "dependencies": {
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/module-type-aliases": "3.2.1",
+        "@docusaurus/theme-common": "3.2.1",
+        "@docusaurus/types": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "mermaid": "^10.4.0",
         "tslib": "^2.6.0"
       },
@@ -2654,19 +2923,58 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.1.tgz",
+      "integrity": "sha512-FyViV5TqhL1vsM7eh29nJ5NtbRE6Ra6LP1PDcPvhwPSlA7eiWGRKAn3jWwMUcmjkos5SYY+sr0/feCdbM3eQHQ==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "3.2.1",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-mermaid/node_modules/@docusaurus/types": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.1.tgz",
+      "integrity": "sha512-n/toxBzL2oxTtRTOFiGKsHypzn/Pm+sXyw+VSk1UbqbXQiHOwHwts55bpKwbcUgA530Is6kix3ELiFOv9GAMfw==",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
-      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.1.tgz",
+      "integrity": "sha512-bzhCrpyXBXzeydNUH83II2akvFEGfhsNTPPWsk5N7e+odgQCQwoHhcF+2qILbQXjaoZ6B3c48hrvkyCpeyqGHw==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/plugin-content-docs": "3.4.0",
-        "@docusaurus/theme-common": "3.4.0",
-        "@docusaurus/theme-translations": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
+        "@docusaurus/core": "3.2.1",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/plugin-content-docs": "3.2.1",
+        "@docusaurus/theme-common": "3.2.1",
+        "@docusaurus/theme-translations": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-validation": "3.2.1",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2685,9 +2993,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
-      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.2.1.tgz",
+      "integrity": "sha512-jAUMkIkFfY+OAhJhv6mV8zlwY6J4AQxJPTgLdR2l+Otof9+QdJjHNh/ifVEu9q0lp3oSPlJj9l05AaP7Ref+cg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2697,9 +3005,10 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
-      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.0.tgz",
+      "integrity": "sha512-uG3FfTkkkbZIPPNYx6xRfZHKeGyRd/inIT1cqvYt1FobFLd+7WhRXrSBqwJ9JajJjEAjNioRMVFgGofGf/Wdww==",
+      "devOptional": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2717,13 +3026,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
-      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-DPkIS/EPc+pGAV798PUXgNzJFM3HJouoQXgr0KDZuJVz1EkWbDLOcQwLIz8Qx7liI9ddfkN/TXTRQdsTPZNakw==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "@svgr/webpack": "^8.1.0",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
+        "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
@@ -2739,7 +3048,6 @@
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2755,9 +3063,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
-      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.2.1.tgz",
+      "integrity": "sha512-N5vadULnRLiqX2QfTjVEU3u5vo6RG2EZTdyXvJdzDOdrLCGIZAfnf/VkssinFZ922sVfaFfQ4FnStdhn5TWdVg==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2774,17 +3082,15 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
-      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.2.1.tgz",
+      "integrity": "sha512-+x7IR9hNMXi62L1YAglwd0s95fR7+EtirjTxSN4kahYRWGqOi3jlQl1EV0az/yTEvKbxVvOPcdYicGu9dk4LJw==",
       "dependencies": {
-        "@docusaurus/logger": "3.4.0",
-        "@docusaurus/utils": "3.4.0",
-        "@docusaurus/utils-common": "3.4.0",
-        "fs-extra": "^11.2.0",
+        "@docusaurus/logger": "3.2.1",
+        "@docusaurus/utils": "3.2.1",
+        "@docusaurus/utils-common": "3.2.1",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3057,11 +3363,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
-      "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.5.1.tgz",
+      "integrity": "sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3102,11 +3408,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
-      "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-6.5.1.tgz",
+      "integrity": "sha512-8DPaVVE3fd5JKuIC29dqyMB54sA6mfgki2H2+swh+zNJoynC8pMPzOkidqHOSc6Wj032fhl8Z0TVn1GiPpAiJg==",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3117,11 +3423,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
-      "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-6.5.1.tgz",
+      "integrity": "sha512-FwOEi0Il72iAzlkaHrlemVurgSQRDFbk0OC8dSvD5fSBPHltNh7JtLsxmZUhjYBZo2PpcU/RJvvi6Q0l7O7ogw==",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3132,11 +3438,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
-      "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-6.5.1.tgz",
+      "integrity": "sha512-gWGsiwjb4tw+ITOJ86ndY/DZZ6cuXMNE/SjcDRg+HLuCmwpcjOktwRF9WgAiycTqJD/QXqL2f8IzE2Rzh7aVXA==",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3147,11 +3453,11 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
-      "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-6.5.1.tgz",
+      "integrity": "sha512-2jT3nTayyYP7kI6aGutkyfJ7UMGtuguD72OjeGLwVNyfPRBD8zQthlvL+fAbAKk5n9ZNcvFkp/b1lZ7VsYqVJg==",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3162,9 +3468,9 @@
       }
     },
     "node_modules/@svgr/babel-plugin-transform-svg-component": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
-      "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-6.5.1.tgz",
+      "integrity": "sha512-a1p6LF5Jt33O3rZoVRBqdxL350oge54iZWHNI6LJB5tQ7EelvD/Mb1mfBiZNAan0dt4i3VArkFRjA4iObuNykQ==",
       "engines": {
         "node": ">=12"
       },
@@ -3177,21 +3483,21 @@
       }
     },
     "node_modules/@svgr/babel-preset": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-8.1.0.tgz",
-      "integrity": "sha512-7EYDbHE7MxHpv4sxvnVPngw5fuR6pw79SkcrILHJ/iMpuKySNCl5W1qcwPEpU+LgyRXOaAFgH0KhwD18wwg6ug==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-6.5.1.tgz",
+      "integrity": "sha512-6127fvO/FF2oi5EzSQOAjo1LE3OtNVh11R+/8FXa+mHx1ptAaS4cknIjnUA7e6j6fwGGJ17NzaTJFUwOV2zwCw==",
       "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": "8.0.0",
-        "@svgr/babel-plugin-remove-jsx-attribute": "8.0.0",
-        "@svgr/babel-plugin-remove-jsx-empty-expression": "8.0.0",
-        "@svgr/babel-plugin-replace-jsx-attribute-value": "8.0.0",
-        "@svgr/babel-plugin-svg-dynamic-title": "8.0.0",
-        "@svgr/babel-plugin-svg-em-dimensions": "8.0.0",
-        "@svgr/babel-plugin-transform-react-native-svg": "8.1.0",
-        "@svgr/babel-plugin-transform-svg-component": "8.0.0"
+        "@svgr/babel-plugin-add-jsx-attribute": "^6.5.1",
+        "@svgr/babel-plugin-remove-jsx-attribute": "*",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "*",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^6.5.1",
+        "@svgr/babel-plugin-svg-dynamic-title": "^6.5.1",
+        "@svgr/babel-plugin-svg-em-dimensions": "^6.5.1",
+        "@svgr/babel-plugin-transform-react-native-svg": "^6.5.1",
+        "@svgr/babel-plugin-transform-svg-component": "^6.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3202,18 +3508,18 @@
       }
     },
     "node_modules/@svgr/core": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
-      "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.1.tgz",
+      "integrity": "sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==",
       "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "8.1.0",
+        "@babel/core": "^7.19.6",
+        "@svgr/babel-preset": "^6.5.1",
+        "@svgr/plugin-jsx": "^6.5.1",
         "camelcase": "^6.2.0",
-        "cosmiconfig": "^8.1.3",
-        "snake-case": "^3.0.4"
+        "cosmiconfig": "^7.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3221,15 +3527,15 @@
       }
     },
     "node_modules/@svgr/hast-util-to-babel-ast": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
-      "integrity": "sha512-EbDKwO9GpfWP4jN9sGdYwPBU0kdomaPIL2Eu4YwmgP+sJeXT+L7bMwJUBnhzfH8Q2qMBqZ4fJwpCyYsAN3mt2Q==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-6.5.1.tgz",
+      "integrity": "sha512-1hnUxxjd83EAxbL4a0JDJoD3Dao3hmjvyvyEV8PzWmLK3B9m9NPlW7GKjFyoWE8nM7HnXzPcmmSyOW8yOddSXw==",
       "dependencies": {
-        "@babel/types": "^7.21.3",
+        "@babel/types": "^7.20.0",
         "entities": "^4.4.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3237,37 +3543,37 @@
       }
     },
     "node_modules/@svgr/plugin-jsx": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-8.1.0.tgz",
-      "integrity": "sha512-0xiIyBsLlr8quN+WyuxooNW9RJ0Dpr8uOnH/xrCVO8GLUcwHISwj1AG0k+LFzteTkAA0GbX0kj9q6Dk70PTiPA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-6.5.1.tgz",
+      "integrity": "sha512-+UdQxI3jgtSjCykNSlEMuy1jSRQlGC7pqBCPvkG/2dATdWo082zHTTK3uhnAju2/6XpE6B5mZ3z4Z8Ns01S8Gw==",
       "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@svgr/babel-preset": "8.1.0",
-        "@svgr/hast-util-to-babel-ast": "8.0.0",
+        "@babel/core": "^7.19.6",
+        "@svgr/babel-preset": "^6.5.1",
+        "@svgr/hast-util-to-babel-ast": "^6.5.1",
         "svg-parser": "^2.0.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
       },
       "peerDependencies": {
-        "@svgr/core": "*"
+        "@svgr/core": "^6.0.0"
       }
     },
     "node_modules/@svgr/plugin-svgo": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-8.1.0.tgz",
-      "integrity": "sha512-Ywtl837OGO9pTLIN/onoWLmDQ4zFUycI1g76vuKGEz6evR/ZTJlJuz3G/fIkb6OVBJ2g0o6CGJzaEjfmEo3AHA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-6.5.1.tgz",
+      "integrity": "sha512-omvZKf8ixP9z6GWgwbtmP9qQMPX4ODXi+wzbVZgomNFsUIlHA1sf4fThdwTWSsZGgvGAG6yE+b/F5gWUkcZ/iQ==",
       "dependencies": {
-        "cosmiconfig": "^8.1.3",
-        "deepmerge": "^4.3.1",
-        "svgo": "^3.0.2"
+        "cosmiconfig": "^7.0.1",
+        "deepmerge": "^4.2.2",
+        "svgo": "^2.8.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3278,21 +3584,21 @@
       }
     },
     "node_modules/@svgr/webpack": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
-      "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-6.5.1.tgz",
+      "integrity": "sha512-cQ/AsnBkXPkEK8cLbv4Dm7JGXq2XrumKnL1dRpJD9rIO2fTIlJI9a1uCciYG1F2aUsox/hJQyNGbt3soDxSRkA==",
       "dependencies": {
-        "@babel/core": "^7.21.3",
-        "@babel/plugin-transform-react-constant-elements": "^7.21.3",
-        "@babel/preset-env": "^7.20.2",
+        "@babel/core": "^7.19.6",
+        "@babel/plugin-transform-react-constant-elements": "^7.18.12",
+        "@babel/preset-env": "^7.19.4",
         "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.21.0",
-        "@svgr/core": "8.1.0",
-        "@svgr/plugin-jsx": "8.1.0",
-        "@svgr/plugin-svgo": "8.1.0"
+        "@babel/preset-typescript": "^7.18.6",
+        "@svgr/core": "^6.5.1",
+        "@svgr/plugin-jsx": "^6.5.1",
+        "@svgr/plugin-svgo": "^6.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       },
       "funding": {
         "type": "github",
@@ -3989,9 +4295,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
-      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.18.0.tgz",
+      "integrity": "sha512-ZXvA8r6VG46V343jnIE7Tei8Xr0/9N8YhD27joC0BKxeogQyvNu7O37i510wA7FnrDjoa/tFhK90WUaBlkaqnw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -4362,11 +4668,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dependencies": {
-        "fill-range": "^7.1.1"
+        "fill-range": "^7.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -5099,28 +5405,18 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "node": ">=10"
       }
     },
     "node_modules/cross-spawn": {
@@ -5162,11 +5458,11 @@
       }
     },
     "node_modules/css-declaration-sorter": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
-      "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+      "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": "^10 || ^12 || >=14"
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
@@ -5207,16 +5503,16 @@
       }
     },
     "node_modules/css-minimizer-webpack-plugin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-5.0.1.tgz",
-      "integrity": "sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
+      "integrity": "sha512-s3Of/4jKfw1Hj9CxEO1E5oXhQAxlayuHO2y/ML+C6I9sQ7FdzfEV6QgMLN3vI+qFsjJGIAFLKtQK7t8BOXAIyA==",
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "cssnano": "^6.0.1",
-        "jest-worker": "^29.4.3",
-        "postcss": "^8.4.24",
-        "schema-utils": "^4.0.1",
-        "serialize-javascript": "^6.0.1"
+        "cssnano": "^5.1.8",
+        "jest-worker": "^29.1.2",
+        "postcss": "^8.4.17",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1"
       },
       "engines": {
         "node": ">= 14.15.0"
@@ -5249,6 +5545,14 @@
         }
       }
     },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -5270,15 +5574,23 @@
       "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g=="
     },
     "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
       },
       "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/css-what": {
@@ -5304,127 +5616,107 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
-      "integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.15.tgz",
+      "integrity": "sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==",
       "dependencies": {
-        "cssnano-preset-default": "^6.1.2",
-        "lilconfig": "^3.1.1"
+        "cssnano-preset-default": "^5.2.14",
+        "lilconfig": "^2.0.3",
+        "yaml": "^1.10.2"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/cssnano"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-6.1.2.tgz",
-      "integrity": "sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
+      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
       "dependencies": {
-        "autoprefixer": "^10.4.19",
-        "browserslist": "^4.23.0",
-        "cssnano-preset-default": "^6.1.2",
-        "postcss-discard-unused": "^6.0.5",
-        "postcss-merge-idents": "^6.0.3",
-        "postcss-reduce-idents": "^6.0.3",
-        "postcss-zindex": "^6.0.2"
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.14",
+        "postcss-discard-unused": "^5.1.0",
+        "postcss-merge-idents": "^5.1.1",
+        "postcss-reduce-idents": "^5.2.0",
+        "postcss-zindex": "^5.1.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
-      "integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "css-declaration-sorter": "^7.2.0",
-        "cssnano-utils": "^4.0.2",
-        "postcss-calc": "^9.0.1",
-        "postcss-colormin": "^6.1.0",
-        "postcss-convert-values": "^6.1.0",
-        "postcss-discard-comments": "^6.0.2",
-        "postcss-discard-duplicates": "^6.0.3",
-        "postcss-discard-empty": "^6.0.3",
-        "postcss-discard-overridden": "^6.0.2",
-        "postcss-merge-longhand": "^6.0.5",
-        "postcss-merge-rules": "^6.1.1",
-        "postcss-minify-font-values": "^6.1.0",
-        "postcss-minify-gradients": "^6.0.3",
-        "postcss-minify-params": "^6.1.0",
-        "postcss-minify-selectors": "^6.0.4",
-        "postcss-normalize-charset": "^6.0.2",
-        "postcss-normalize-display-values": "^6.0.2",
-        "postcss-normalize-positions": "^6.0.2",
-        "postcss-normalize-repeat-style": "^6.0.2",
-        "postcss-normalize-string": "^6.0.2",
-        "postcss-normalize-timing-functions": "^6.0.2",
-        "postcss-normalize-unicode": "^6.1.0",
-        "postcss-normalize-url": "^6.0.2",
-        "postcss-normalize-whitespace": "^6.0.2",
-        "postcss-ordered-values": "^6.0.2",
-        "postcss-reduce-initial": "^6.1.0",
-        "postcss-reduce-transforms": "^6.0.2",
-        "postcss-svgo": "^6.0.3",
-        "postcss-unique-selectors": "^6.0.4"
+        "css-declaration-sorter": "^6.3.1",
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.1",
+        "postcss-convert-values": "^5.1.3",
+        "postcss-discard-comments": "^5.1.2",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.1",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.4",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.1",
+        "postcss-minify-params": "^5.1.4",
+        "postcss-minify-selectors": "^5.2.1",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.1",
+        "postcss-normalize-repeat-style": "^5.1.1",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.1",
+        "postcss-ordered-values": "^5.1.3",
+        "postcss-reduce-initial": "^5.1.2",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.1"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
-      "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
       "dependencies": {
-        "css-tree": "~2.2.0"
+        "css-tree": "^1.1.2"
       },
       "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=8.0.0"
       }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -7008,9 +7300,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -9250,14 +9542,11 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
+        "node": ">=10"
       }
     },
     "node_modules/lines-and-columns": {
@@ -9819,9 +10108,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -12258,6 +12547,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/not": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
@@ -12798,108 +13098,105 @@
       }
     },
     "node_modules/postcss-calc": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
-      "integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
+      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.11",
+        "postcss-selector-parser": "^6.0.9",
         "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || ^16 || >=18.0"
       },
       "peerDependencies": {
         "postcss": "^8.2.2"
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
-      "integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
-        "colord": "^2.9.3",
+        "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
-      "integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
-      "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
+      "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
-      "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
-      "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
+      "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
-      "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-discard-unused": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-6.0.5.tgz",
-      "integrity": "sha512-wHalBlRHkaNnNwfC8z+ppX57VhvS+HWgjW508esjdaEYr3Mx7Gnn2xA4R/CKf5+Z9S5qsqC+Uzh4ueENWwCVUA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-5.1.0.tgz",
+      "integrity": "sha512-KwLWymI9hbwXmJa0dkrzpRbSJEh0vVUd7r8t0yOGPcfKzyJJxFM8kLyC5Ev9avji6nY95pOp1W6HqIrfT+0VGw==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.16"
+        "postcss-selector-parser": "^6.0.5"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-loader": {
@@ -12923,111 +13220,136 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/postcss-merge-idents": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-6.0.3.tgz",
-      "integrity": "sha512-1oIoAsODUs6IHQZkLQGO15uGEbK3EAl5wi9SS8hs45VgsxQfMnxvt+L+zIr7ifZFIH14cfAeVe2uCTa+SPRa3g==",
+    "node_modules/postcss-loader/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dependencies": {
-        "cssnano-utils": "^4.0.2",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-merge-idents": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-5.1.1.tgz",
+      "integrity": "sha512-pCijL1TREiCoog5nQp7wUe+TUonA2tC2sQ54UGeMmryK3UFGIYKqDyjnqd6RcuI4znFn9hWSLNN8xKE/vWcUQw==",
+      "dependencies": {
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
-      "integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^6.1.1"
+        "stylehacks": "^5.1.1"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
-      "integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^4.0.2",
-        "postcss-selector-parser": "^6.0.16"
+        "cssnano-utils": "^3.1.0",
+        "postcss-selector-parser": "^6.0.5"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
-      "integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
-      "integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.1.tgz",
+      "integrity": "sha512-VGvXMTpCEo4qHTNSa9A0a3D+dxGFZCYwR6Jokk+/3oB6flu2/PnPXAh2x7x52EkY5xlIHLm+Le8tJxe/7TNhzw==",
       "dependencies": {
-        "colord": "^2.9.3",
-        "cssnano-utils": "^4.0.2",
+        "colord": "^2.9.1",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
-      "integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "cssnano-utils": "^4.0.2",
+        "browserslist": "^4.21.4",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
-      "integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.1.tgz",
+      "integrity": "sha512-nPJu7OjZJTsVUmPdm2TcaiohIwxP+v8ha9NehQ2ye9szv4orirRU3SDdtUmKH+10nzn0bAyOXZ0UEr7OpvLehg==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.16"
+        "postcss-selector-parser": "^6.0.5"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-modules-extract-imports": {
@@ -13086,185 +13408,186 @@
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
-      "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
-      "integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
-      "integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.1.tgz",
+      "integrity": "sha512-6UpCb0G4eofTCQLFVuI3EVNZzBNPiIKcA1AKVka+31fTVySphr3VUgAIULBhxZkKgwLImhzMR2Bw1ORK+37INg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
-      "integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.1.tgz",
+      "integrity": "sha512-mFpLspGWkQtBcWIRFLmewo8aC3ImN2i/J3v8YCFUwDnPu3Xz4rLohDO26lGjwNsQxB3YF0KKRwspGzE2JEuS0g==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
-      "integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
-      "integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
-      "integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
-      "integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
       "dependencies": {
+        "normalize-url": "^6.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
-      "integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.1.tgz",
+      "integrity": "sha512-83ZJ4t3NUDETIHTa3uEg6asWjSBYL5EdkVB0sDncx9ERzOKBVJIUeDO9RyA9Zwtig8El1d79HBp0JEi8wvGQnA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
-      "integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.3.tgz",
+      "integrity": "sha512-9UO79VUhPwEkzbb3RNpqqghc6lcYej1aveQteWY+4POIwlqkYE21HKWaLDF6lWNuqCobEAyTovVhtI32Rbv2RQ==",
       "dependencies": {
-        "cssnano-utils": "^4.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-reduce-idents": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-6.0.3.tgz",
-      "integrity": "sha512-G3yCqZDpsNPoQgbDUy3T0E6hqOQ5xigUtBQyrmq3tn2GxlyiL0yyl7H+T8ulQR6kOcHJ9t7/9H4/R2tv8tJbMA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-5.2.0.tgz",
+      "integrity": "sha512-BTrLjICoSB6gxbc58D5mdBK8OhXRDqud/zodYfdSi52qvDHdMwk+9kB9xsM8yJThH/sZU5A6QVSmMmaN001gIg==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
-      "integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
       "dependencies": {
-        "browserslist": "^4.23.0",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
-      "integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -13280,46 +13603,46 @@
       }
     },
     "node_modules/postcss-sort-media-queries": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-5.2.0.tgz",
-      "integrity": "sha512-AZ5fDMLD8SldlAYlvi8NIqo0+Z8xnXU2ia0jxmuhxAU+Lqt9K+AlmLNJ/zWEnE9x+Zx3qL3+1K20ATgNOr3fAA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
+      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
       "dependencies": {
-        "sort-css-media-queries": "2.2.0"
+        "sort-css-media-queries": "2.1.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.23"
+        "postcss": "^8.4.16"
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
-      "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "svgo": "^3.2.0"
+        "svgo": "^2.7.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >= 18"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
-      "integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz",
+      "integrity": "sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.16"
+        "postcss-selector-parser": "^6.0.5"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -13328,14 +13651,14 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/postcss-zindex": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-6.0.2.tgz",
-      "integrity": "sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
+      "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/pretty-error": {
@@ -13743,9 +14066,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
-      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.3.0.tgz",
+      "integrity": "sha512-aN1biKC5v4DQkmQBlZjuMFR09MKZGMPtIg+cut8zEeg2HXd6gl2gRy0n4HMacHf0dznQgo0SVXN7eT8zV3hEuQ==",
       "engines": {
         "node": ">=14"
       },
@@ -13758,7 +14081,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
       "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "peer": true,
       "dependencies": {
         "@types/react": "*",
         "prop-types": "^15.6.2"
@@ -14463,9 +14785,9 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.14.0.tgz",
-      "integrity": "sha512-OLN6MsPMCghDOqlCtsIsYgtsC0pnwVTyT9Mu6A3ewOj1DxvzZF6COrn2g86E/c05xbktB0XN04m/t1Z+n+fTGw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -14823,9 +15145,9 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/sitemap": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.2.tgz",
-      "integrity": "sha512-ARCqzHJ0p4gWt+j7NlU5eDlIO9+Rkr/JhPFZKKQ1l5GCus7rJH4UdrlVAh0xC/gDS/Qir2UMxqYNHtsKr2rpCw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
+      "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -14864,15 +15186,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -14884,9 +15197,9 @@
       }
     },
     "node_modules/sort-css-media-queries": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.2.0.tgz",
-      "integrity": "sha512-0xtkGhWCC9MGt/EzgnvbbbKhqWjl1+/rncmhTh5qCpbYguXh6S/qwePfv/JQ8jePXXmqingylxoC49pCkSPIbA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.1.0.tgz",
+      "integrity": "sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA==",
       "engines": {
         "node": ">= 6.3.0"
       }
@@ -14976,6 +15289,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15112,18 +15431,18 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
-      "integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "dependencies": {
-        "browserslist": "^4.23.0",
-        "postcss-selector-parser": "^6.0.16"
+        "browserslist": "^4.21.4",
+        "postcss-selector-parser": "^6.0.4"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18.0"
+        "node": "^10 || ^12 || >=14.0"
       },
       "peerDependencies": {
-        "postcss": "^8.4.31"
+        "postcss": "^8.2.15"
       }
     },
     "node_modules/stylis": {
@@ -15159,27 +15478,23 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
       },
       "bin": {
         "svgo": "bin/svgo"
       },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/svgo/node_modules/commander": {
@@ -15188,6 +15503,69 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/svgo/node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/svgo/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/svgo/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/svgo/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/svgo/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/plugin-client-redirects": "^3.4.0",
-    "@docusaurus/plugin-content-docs": "^3.4.0",
-    "@docusaurus/plugin-google-gtag": "^3.4.0",
-    "@docusaurus/plugin-google-tag-manager": "^3.4.0",
-    "@docusaurus/preset-classic": "^3.4.0",
-    "@docusaurus/theme-mermaid": "^3.4.0",
+    "@docusaurus/core": "3.2.1",
+    "@docusaurus/plugin-client-redirects": "^3.2.1",
+    "@docusaurus/plugin-content-docs": "^3.2.1",
+    "@docusaurus/plugin-google-gtag": "^3.2.1",
+    "@docusaurus/plugin-google-tag-manager": "^3.2.1",
+    "@docusaurus/preset-classic": "3.2.1",
+    "@docusaurus/theme-mermaid": "^3.2.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "docusaurus-lunr-search": "^3.3.2",
@@ -30,8 +30,8 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/types": "^3.4.0"
+    "@docusaurus/module-type-aliases": "3.2.0",
+    "@docusaurus/types": "3.2.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

This PR reverts Docusaurus from v3.4.0 to v3.2.1. Both versions have the following issues regarding Algolia DocSearch:

- **v3.2.1**
  - When searching the docs site by using Algolia DocSearch, selecting the section heading of a page, and then pressing `Ctrl + F` to search the page, the page becomes unresponsive and must be refreshed in order for users to navigate the page.
- **v3.4.0**
  - When searching the docs site by using Algolia DocSearch, selecting the section heading of a page, and then pressing `Ctrl + F` to search the page, a key binding issue occurs that causes the Algolia DocSearch modal to open and search for the letter `f` instead of the browser opening its built-in “Find” function, which is standard behavior. Users must then click outside of the modal window to close it, or they must click elsewhere on the screen before pressing `Ctrl + F` to use the "Find" function on the page.

## Related issues and/or PRs

- #340 

## Changes made

- Reverted the changes dependencies for Docusaurus back to v3.2.1.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A