### PR TITLE
Add ScalarDL command reference doc to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -247,6 +247,7 @@ const sidebars = {
       collapsible: true,
       items: [
         'compatibility',
+        'scalardl-command-reference',
         'scalardl-benchmarks/README',
       ],
     },


### PR DESCRIPTION
## Description

This PR adds the ScalarDL Command Reference doc to the sidebar navigation.

## Related issues and/or PRs

- #355 
- #363

## Changes made

- Added the ScalarDL Command Reference doc to the sidebar navigation for version 3.9.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A