### PR TITLE
Add function to hide sidebar navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,6 +167,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      docs: {
+        sidebar: {
+          hideable: true,
+        },
+      },
       // Replace with your project's social card
       image: 'img/scalardl-logo.png',
       navbar: {


### PR DESCRIPTION
## Description

This PR adds the function to hide sidebar navigation. By being able to hide the sidebar, visitors can choose to hide the sidebar navigation and see more page content.

## Related issues and/or PRs

N/A

## Changes made

- Added the function to hide the sidebar navigation, according to the [Docusaurus documentation for the hideable sidebar](https://docusaurus.io/docs/sidebar#hideable-sidebar).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A