### PR TITLE
Add home pages for each version

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 # ScalarDL
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards';
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.9';
 
 ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
 

--- a/src/components/Cards/3.4.tsx
+++ b/src/components/Cards/3.4.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Implementation
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL Auditor
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Bank account application
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/escrow-payment',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Escrow payment CLI
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Load a database schema
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Get a certificate for the network
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDL on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDL Ledger production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDL in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Compatibility matrix
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.5.tsx
+++ b/src/components/Cards/3.5.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Implementation
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL Auditor
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Bank account application
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/escrow-payment',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Escrow payment CLI
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Load a database schema
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Get a certificate for the network
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDL on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDL Ledger production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDL in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Compatibility matrix
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.6.tsx
+++ b/src/components/Cards/3.6.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'design',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Design
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Implementation
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL Auditor
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Bank account application
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/escrow-payment',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Escrow payment CLI
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Load a database schema
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Get a certificate for the network
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDL on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDL Ledger production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDL in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Compatibility matrix
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.7.tsx
+++ b/src/components/Cards/3.7.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Implementation
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL Auditor
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Bank account application
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/escrow-payment',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Escrow payment CLI
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Load a database schema
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Get a certificate for the network
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDL on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDL Ledger production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDL in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Compatibility matrix
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.8.tsx
+++ b/src/components/Cards/3.8.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Overview
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        Implementation
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        Getting started with ScalarDL Auditor
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Bank account application
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/escrow-payment',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        Escrow payment CLI
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Load a database schema
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        Get a certificate for the network
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        Set up a database for ScalarDL on AWS
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        See the ScalarDL Ledger production checklist
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Monitor ScalarDL in a Kubernetes cluster
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Back up and restore in a Kubernetes environment
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Compatibility matrix
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        Benchmarking tools
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -17,7 +17,7 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'overview/',
+      page: 'overview',
     },
     description: (
       <Translate id="home.about.description">
@@ -29,7 +29,7 @@ const CardsAbout = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'implementation/',
+      page: 'implementation',
     },
     description: (
       <Translate id="home.about.description">
@@ -44,7 +44,7 @@ const CardsGettingStarted = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'getting-started/',
+      page: 'getting-started',
     },
     description: (
       <Translate id="home.gettingStarted.description">
@@ -56,7 +56,7 @@ const CardsGettingStarted = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'getting-started-auditor/',
+      page: 'getting-started-auditor',
     },
     description: (
       <Translate id="home.gettingStarted.description">
@@ -71,7 +71,7 @@ const CardsSamples = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'applications/simple-bank-account/',
+      page: 'applications/simple-bank-account',
     },
     description: (
       <Translate id="home.samples.description">
@@ -83,7 +83,7 @@ const CardsSamples = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'applications/escrow-payment/',
+      page: 'applications/escrow-payment',
     },
     description: (
       <Translate id="home.samples.description">
@@ -98,7 +98,7 @@ const CardsDevelop = [
     // name: 'For database engineers',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'schema-loader/',
+      page: 'schema-loader',
     },
     description: (
       <Translate id="home.develop.description">
@@ -110,7 +110,7 @@ const CardsDevelop = [
     // name: 'For infrastructure engineers',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'ca/caclient-getting-started/',
+      page: 'ca/caclient-getting-started',
     },
     description: (
       <Translate id="home.develop.description">
@@ -125,7 +125,7 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/SetupDatabaseForAWS/',
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
     },
     description: (
       <Translate id="home.deploy.description">
@@ -137,7 +137,7 @@ const CardsDeploy = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger/',
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
     },
     description: (
       <Translate id="home.deploy.description">
@@ -152,7 +152,7 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/K8sMonitorGuide/',
+      page: 'scalar-kubernetes/K8sMonitorGuide',
     },
     description: (
       <Translate id="home.manage.description">
@@ -164,7 +164,7 @@ const CardsManage = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalar-kubernetes/BackupRestoreGuide/',
+      page: 'scalar-kubernetes/BackupRestoreGuide',
     },
     description: (
       <Translate id="home.manage.description">
@@ -179,7 +179,7 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'compatibility/',
+      page: 'compatibility',
     },
     description: (
       <Translate id="home.reference.description">
@@ -191,7 +191,7 @@ const CardsReference = [
     // name: '',
     // image: '<LINK_TO>.png',
     url: {
-      page: 'scalardl-benchmarks/',
+      page: 'scalardl-benchmarks',
     },
     description: (
       <Translate id="home.reference.description">

--- a/versioned_docs/version-3.4/index.mdx
+++ b/versioned_docs/version-3.4/index.mdx
@@ -1,0 +1,46 @@
+# ScalarDL
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.4';
+
+ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
+
+**About ScalarDL**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/versioned_docs/version-3.5/index.mdx
+++ b/versioned_docs/version-3.5/index.mdx
@@ -1,0 +1,46 @@
+# ScalarDL
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.5';
+
+ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
+
+**About ScalarDL**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/versioned_docs/version-3.6/index.mdx
+++ b/versioned_docs/version-3.6/index.mdx
@@ -1,0 +1,46 @@
+# ScalarDL
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.6';
+
+ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
+
+**About ScalarDL**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/versioned_docs/version-3.7/index.mdx
+++ b/versioned_docs/version-3.7/index.mdx
@@ -1,0 +1,46 @@
+# ScalarDL
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.7';
+
+ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
+
+**About ScalarDL**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/versioned_docs/version-3.8/index.mdx
+++ b/versioned_docs/version-3.8/index.mdx
@@ -1,0 +1,46 @@
+# ScalarDL
+
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.8';
+
+ScalarDL is scalable and practical Byzantine fault detection middleware for transactional database systems that achieves correctness, scalability, and database agnosticism.
+
+**About ScalarDL**
+
+<CardRowAbout />
+
+**Getting started**
+
+<CardRowGettingStarted />
+
+**Samples**
+
+<CardRowSamples />
+
+**Develop**
+
+<CardRowDevelop />
+
+**Deploy**
+
+<CardRowDeploy />
+
+**Manage**
+
+<CardRowManage />
+
+**Reference**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/versioned_sidebars/version-3.4-sidebars.json
+++ b/versioned_sidebars/version-3.4-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDL Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.5-sidebars.json
+++ b/versioned_sidebars/version-3.5-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDL Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.6-sidebars.json
+++ b/versioned_sidebars/version-3.6-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDL Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDL Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -1,9 +1,9 @@
 {
   "docs": [
     {
-      "type": "link",
+      "type": "doc",
       "label": "ScalarDL Docs Home",
-      "href": "/docs/latest/"
+      "id": "index"
     },
     {
       "type": "category",


### PR DESCRIPTION
## Description

This PR adds an index (home page) page for each version.

Previously, there was only one home page, which directed to the latest version of the docs. Because of this, if a visitor selected `ScalarDL Docs Home` at the top of the sidebar navigation, they would be taken to the home page of the latest version of the docs. In this case, the expected behavior would be to navigate to the home page for the version that the user is currently on.

## Related issues and/or PRs

N/A

## Changes made

- Added an index page to each version of the docs.
- Added a component with links to available docs for that version.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A