### PR TITLE
Move design doc above implementation doc in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -30,8 +30,8 @@ const sidebars = {
       'collapsible': true,
       'items': [
         'overview',
-        'implementation',
         'design',
+        'implementation',
         'roadmap',
       ]
     },

--- a/versioned_sidebars/version-3.7-sidebars.json
+++ b/versioned_sidebars/version-3.7-sidebars.json
@@ -11,8 +11,8 @@
       "collapsible": true,
       "items": [
         "overview",
-        "implementation",
-        "design"
+        "design",
+        "implementation"
       ]
     },
     {

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -11,8 +11,8 @@
       "collapsible": true,
       "items": [
         "overview",
-        "implementation",
-        "design"
+        "design",
+        "implementation"
       ]
     },
     {


### PR DESCRIPTION
## Description

This PR moves the design doc above the implementation doc in the sidebar navigation. From a development process perspective, the design doc should be shown first since it describes the design of ScalarDL.

## Related issues and/or PRs

N/A

## Changes made

- Moved the design doc above the implementation doc in the sidebar navigation for versions that are under Maintenance Support.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A