### PR TITLE
Hide tags in docs footer

### DIFF
--- a/src/theme/TagsListInline/index.tsx
+++ b/src/theme/TagsListInline/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Tag from '@theme/Tag';
+import type {Props} from '@theme/TagsListInline';
+
+import styles from './styles.module.css';
+
+export default function TagsListInline({tags}: Props): JSX.Element {
+  return (
+    <>
+      <b>
+        <Translate
+          id="theme.tags.tagsListLabel"
+          description="The label alongside a tag list">
+          Tags:
+        </Translate>
+      </b>
+      <ul className={clsx(styles.tags, 'padding--none', 'margin-left--sm')}>
+        {tags.map((tag) => (
+          <li key={tag.permalink} className={styles.tag}>
+            <Tag {...tag} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/theme/TagsListInline/index.tsx
+++ b/src/theme/TagsListInline/index.tsx
@@ -9,7 +9,7 @@ import styles from './styles.module.css';
 export default function TagsListInline({tags}: Props): JSX.Element {
   return (
     <>
-      <b>
+      {/* <b>
         <Translate
           id="theme.tags.tagsListLabel"
           description="The label alongside a tag list">
@@ -22,7 +22,7 @@ export default function TagsListInline({tags}: Props): JSX.Element {
             <Tag {...tag} />
           </li>
         ))}
-      </ul>
+      </ul> */}
     </>
   );
 }

--- a/src/theme/TagsListInline/styles.module.css
+++ b/src/theme/TagsListInline/styles.module.css
@@ -1,0 +1,8 @@
+.tags {
+  display: inline;
+}
+
+.tag {
+  margin: 0 0.4rem 0.5rem 0;
+  display: inline-block;
+}


### PR DESCRIPTION
## Description

This PR hides the tags in the footer of docs. Some of our docs will soon include tags, but we don't want to show those tags in the docs quite yet. To avoid confusion since not all docs will include tags initially, hiding them is better for now.

## Related issues and/or PRs

- In the future, we'll add tags to the top of docs, like in https://github.com/scalar-labs/docs-scalardb/pull/469.

## Changes made

- [Swizzled](https://docusaurus.io/docs/swizzling) the `TagsList Inline` component and hid the tags feature.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A