### PR TITLE
Mark ScalarDL 3.7 as no longer supported

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -36,11 +36,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>**</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -82,9 +82,9 @@ const config = {
                 banner: 'none',
               },
               "3.7": {
-                label: '3.7',
+                label: '3.7 (unsupported)',
                 path: '3.7',
-                banner: 'none',
+                banner: 'unmaintained',
               },
               "3.6": {
                 label: '3.6 (unsupported)',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -40,11 +40,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>**</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
@@ -26,11 +26,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
@@ -33,11 +33,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.7/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.7/releases/release-support-policy.mdx
@@ -22,11 +22,11 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -29,11 +29,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a></td>
-      <td>2022-12-02</td>
-      <td>2024-04-18</td>
-      <td>2024-10-15</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
+      <td class="version-out-of-support">2022-12-02</td>
+      <td class="version-out-of-support">2024-04-18</td>
+      <td class="version-out-of-support">2024-10-15</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>


### PR DESCRIPTION
## Description

This PR marks ScalarDL 3.7 as no longer supported since Assistance Support ended on October 15, 2024.

## Related issues and/or PRs

N/A

## Changes made

- In each version of the Release Support Policy docs:
  - Added an asterisk to `3.7`.
  - Added the `out-of-support` style to the cells in the table.
- In the Docusaurus configuration file:
  - Added `(unsupported)` to `3.7` in the version selector.
  - Added the `unmaintained` banner.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A