### PR TITLE
Fix broken link syntax in release notes

### DIFF
--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -147,8 +147,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 - いくつかの構成の問題、特に TLS を使用した Gateway を修正しました。
 - TLS gRPC ヘルス チェックをサポートするために、Gateway Docker イメージで grpc_health_probe を使用するように修正されました。
 - org.everit.json.schema を 1.14.2 にアップグレードしました。 [CVE-2023-5072](https://github.com/advisories/GHSA-4jq9-2xhw-jpx7 "CVE-2023-5072")
-- セキュリティ問題を修正するために grpc-health-probe をアップグレードしました。 [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8 "CVE-2023-39325") [GHSA-m425-mq94-257g](https://github.com /advisories/GHSA-m425-mq94-257g "GHSA-m425-mq94-257g")
-- セキュリティ問題を修正するために基本イメージをアップグレードしました。 [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2023-4911](https://github.com/advisories/GHSA-m77w-6vjw-wh2f "CVE-2023-4911") [CVE-2023-29491](https://github.com/advisories/GHSA-vh2x-5rx6-qqhv "CVE-2023-29491") [CVE-2023-47038](https://github.com/advisories / GHSA-96fh-9q43-rmjh "CVE-2023-47038")
+- セキュリティ問題を修正するために grpc-health-probe をアップグレードしました。 [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8 "CVE-2023-39325") [GHSA-m425-mq94-257g](https://github.com/advisories/GHSA-m425-mq94-257g "GHSA-m425-mq94-257g")
+- セキュリティ問題を修正するために基本イメージをアップグレードしました。 [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2022-29458](https://github.com/advisories/GHSA-jh4f-5j2m-4v9c "CVE-2022-29458") [CVE-2023-4911](https://github.com/advisories/GHSA-m77w-6vjw-wh2f "CVE-2023-4911") [CVE-2023-29491](https://github.com/advisories/GHSA-vh2x-5rx6-qqhv "CVE-2023-29491") [CVE-2023-47038](https://github.com/advisories/GHSA-96fh-9q43-rmjh "CVE-2023-47038")
 - org.bouncycastle:bcprov-jdk15on を 1.59 から 1.70 にアップグレードしました。 [CVE-2018-1000180](https://github.com/advisories/GHSA-xqj7-j8j5-f2xr "CVE-2018-1000180") [CVE-2018-1000613](https://github.com/advisories/GHSA-4446-656p-f54g "CVE-2018-1000613") [CVE-2020-28052](https://github.com/advisories/GHSA-73xv-w5gp-frxh "CVE-2020-28052")
 
 ### その他


### PR DESCRIPTION
## Description

This PR fixes broken link syntax in the Japanese version of the ScalarDL 3.9 release notes. The link syntax broke after running the original English release notes through Google Translate.

## Related issues and/or PRs

N/A

## Changes made

- Fixed broken link syntax.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas. `N/A`
- [x] I have updated the documentation to reflect the changes. `N/A`
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A