### PR TITLE
Update home pages of 3.8 and 3.9 docs; update Japanese category names in sidebar navigation

### DIFF
--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current.json
@@ -16,7 +16,7 @@
     "description": "The label for category Samples in sidebar docs"
   },
   "sidebar.docs.category.Develop": {
-    "message": "開発する",
+    "message": "開発",
     "description": "The label for category Develop in sidebar docs"
   },
   "sidebar.docs.category.SDKs": {
@@ -24,7 +24,7 @@
     "description": "The label for category Deploy in sidebar docs"
   },
   "sidebar.docs.category.Deploy": {
-    "message": "展開する",
+    "message": "デプロイ",
     "description": "The label for category Deploy in sidebar docs"
   },
   "sidebar.docs.category.Scalar Kubernetes": {
@@ -72,7 +72,7 @@
     "description": "The label for category Backup and Restore Guides in sidebar docs"
   },
   "sidebar.docs.category.Reference": {
-    "message": "参照",
+    "message": "関連情報",
     "description": "The label for category Reference in sidebar docs"
   },
   "sidebar.docs.category.Releases": {

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,11 +1,46 @@
-# ScalarDL: トランザクション データベース システム用のビザンチン障害検出ミドルウェア
+# ScalarDL
 
-import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.9';
 
-<TranslationBanner />
+ScalarDL は、正確性、スケーラビリティ、およびデータベース不可知性を実現する、トランザクションデータベースシステム用のスケーラブルで実用的なビザンチン障害検出ミドルウェアです。
 
-ScalarDL は、正確性、スケーラビリティ、およびデータベース不可知性を実現する、トランザクション データベース システム用のスケーラブルで実用的なビザンチン障害検出ミドルウェアです。
+**ScalarDL について**
 
-## 役立つリソース
-* [ScalarDL Technical Overview](https://speakerdeck.com/scalar/scalar-dl-technical-overview)
-* [ScalarDL Research Paper](https://dl.acm.org/doi/abs/10.14778/3523210.3523212) [VLDB'22]
+<CardRowAbout />
+
+**始めましょう**
+
+<CardRowGettingStarted />
+
+**サンプルアプリケーション**
+
+<CardRowSamples />
+
+**開発**
+
+<CardRowDevelop />
+
+**デプロイ**
+
+<CardRowDeploy />
+
+**管理**
+
+<CardRowManage />
+
+**関連情報**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.7",
+    "message": "3.7 (サポートされていない)",
     "description": "The label for version 3.7"
   },
   "sidebar.docs.category.About ScalarDL": {

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
@@ -16,7 +16,7 @@
     "description": "The label for category Samples in sidebar docs"
   },
   "sidebar.docs.category.Develop": {
-    "message": "開発する",
+    "message": "開発",
     "description": "The label for category Develop in sidebar docs"
   },
   "sidebar.docs.category.SDKs": {
@@ -24,7 +24,7 @@
     "description": "The label for category Deploy in sidebar docs"
   },
   "sidebar.docs.category.Deploy": {
-    "message": "展開する",
+    "message": "デプロイ",
     "description": "The label for category Deploy in sidebar docs"
   },
   "sidebar.docs.category.Scalar Kubernetes": {
@@ -72,7 +72,7 @@
     "description": "The label for category Backup and Restore Guides in sidebar docs"
   },
   "sidebar.docs.category.Reference": {
-    "message": "参照",
+    "message": "関連情報",
     "description": "The label for category Reference in sidebar docs"
   },
   "sidebar.docs.category.Releases": {

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/index.mdx
@@ -1,11 +1,46 @@
-# ScalarDL: トランザクション データベース システム用のビザンチン障害検出ミドルウェア
+# ScalarDL
 
-import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.9';
 
-<TranslationBanner />
+ScalarDL は、正確性、スケーラビリティ、およびデータベース不可知性を実現する、トランザクションデータベースシステム用のスケーラブルで実用的なビザンチン障害検出ミドルウェアです。
 
-ScalarDL は、正確性、スケーラビリティ、およびデータベース不可知性を実現する、トランザクション データベース システム用のスケーラブルで実用的なビザンチン障害検出ミドルウェアです。
+**ScalarDL について**
 
-## 役立つリソース
-* [ScalarDL Technical Overview](https://speakerdeck.com/scalar/scalar-dl-technical-overview)
-* [ScalarDL Research Paper](https://dl.acm.org/doi/abs/10.14778/3523210.3523212) [VLDB'22]
+<CardRowAbout />
+
+**始めましょう**
+
+<CardRowGettingStarted />
+
+**サンプルアプリケーション**
+
+<CardRowSamples />
+
+**開発**
+
+<CardRowDevelop />
+
+**デプロイ**
+
+<CardRowDeploy />
+
+**管理**
+
+<CardRowManage />
+
+**関連情報**
+
+<CardRowReference />
+
+{/* Saving the following in case we decide to change the layout in the future to a more table grid-like style. */}
+{/*
+| Category            | Documentation         |
+|:------------------- |:--------------------- |
+| **About ScalarDL**  | <a href="XXX">XXX</a> |
+| **Getting started** | <a href="XXX">XXX</a> |
+| **Samples**         | <a href="XXX">XXX</a> |
+| **Develop**         | <a href="XXX">XXX</a> |
+| **Deploy**          | <a href="XXX">XXX</a> |
+| **Manage**          | <a href="XXX">XXX</a> |
+| **Reference**       | <a href="XXX">XXX</a> |
+*/}

--- a/src/components/Cards/3.8.tsx
+++ b/src/components/Cards/3.8.tsx
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a bank account application
+        Run a bank account application
       </Translate>
     ),
   },

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -87,7 +87,7 @@ const CardsSamples = [
     },
     description: (
       <Translate id="home.samples.description">
-        Create a bank account application
+        Run a bank account application
       </Translate>
     ),
   },

--- a/src/components/Cards/ja-jp/3.8.tsx
+++ b/src/components/Cards/ja-jp/3.8.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        概要
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        実装
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        ScalarDL Ledger をはじめよう
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        ScalarDL Auditor をはじめよう
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'installation-with-docker',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        ローカル環境に ScalarDL をインストールする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        銀行口座申請を実行する
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        データベーススキーマをロードする
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        証明書を取得する
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        AWS でデータベースをセットアップする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        ScalarDL Ledger の本番環境チェックリスト
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Kubernetes クラスター上の ScalarDLの監視
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Kubernetes 環境でデータをバックアップおよび復元する
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        互換性マトリックス
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ベンチマークツール
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Cards/ja-jp/3.9.tsx
+++ b/src/components/Cards/ja-jp/3.9.tsx
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable global-require */
+
+import React from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import Link from '@docusaurus/Link';
+
+const CardsAbout = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'overview',
+    },
+    description: (
+      <Translate id="home.about.description">
+        概要
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'implementation',
+    },
+    description: (
+      <Translate id="home.about.description">
+        実装
+      </Translate>
+    ),
+  },
+]
+
+const CardsGettingStarted = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        ScalarDL Ledger をはじめよう
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'getting-started-auditor',
+    },
+    description: (
+      <Translate id="home.gettingStarted.description">
+        ScalarDL Auditor をはじめよう
+      </Translate>
+    ),
+  },
+]
+
+const CardsSamples = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'installation-with-docker',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        ローカル環境に ScalarDL をインストールする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'applications/simple-bank-account',
+    },
+    description: (
+      <Translate id="home.samples.description">
+        銀行口座申請を実行する
+      </Translate>
+    ),
+  },
+]
+
+const CardsDevelop = [
+  {
+    // name: 'For database engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'schema-loader',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        データベーススキーマをロードする
+      </Translate>
+    ),
+  },
+  {
+    // name: 'For infrastructure engineers',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'ca/caclient-getting-started',
+    },
+    description: (
+      <Translate id="home.develop.description">
+        証明書を取得する
+      </Translate>
+    ),
+  },
+]
+
+const CardsDeploy = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/SetupDatabaseForAWS',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        AWS でデータベースをセットアップする
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/ProductionChecklistForScalarDLLedger',
+    },
+    description: (
+      <Translate id="home.deploy.description">
+        ScalarDL Ledger の本番環境チェックリスト
+      </Translate>
+    ),
+  },
+]
+
+const CardsManage = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/K8sMonitorGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Kubernetes クラスター上の ScalarDLの監視
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalar-kubernetes/BackupRestoreGuide',
+    },
+    description: (
+      <Translate id="home.manage.description">
+        Kubernetes 環境でデータをバックアップおよび復元する
+      </Translate>
+    ),
+  },
+]
+
+const CardsReference = [
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'compatibility',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        互換性マトリックス
+      </Translate>
+    ),
+  },
+  {
+    // name: '',
+    // image: '<LINK_TO>.png',
+    url: {
+      page: 'scalardl-benchmarks',
+    },
+    description: (
+      <Translate id="home.reference.description">
+        ベンチマークツール
+      </Translate>
+    ),
+  },
+];
+
+interface Props {
+  // name: string;
+  // image: string;
+  url: {
+    page?: string;
+  };
+  description: JSX.Element;
+}
+
+function Card({ /* name, image,*/ url, description }: Props) {
+  return (
+    <div className="col col--6 margin-bottom--lg">
+      <div className={clsx('card')}>
+        <div className={clsx('card__image')}>
+          {/* <Link to={url.page}>
+            <img src={image}></img>}
+          </Link> */}
+        </div>
+        <Link to={url.page}>
+          <div className="card__body">
+            {/* <h3>{name}</h3> */}
+            <p>{description}</p>
+          </div>
+        </Link>
+        {/* <div className="card__footer">
+          <div className="button-group button-group--block">
+            <Link className="button button--secondary" to={url.page}>
+              <Translate id="button.readMore">Read more</Translate>
+            </Link>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}
+
+export function CardRowAbout(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsAbout.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowGettingStarted(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsGettingStarted.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowSamples(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsSamples.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDevelop(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDevelop.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowDeploy(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsDeploy.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+
+export function CardRowManage(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsManage.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}
+export function CardRowReference(): JSX.Element {
+  return (
+    <div className="row">
+      {CardsReference.map((special) => (
+        <Card key={special.name} {...special} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR updates the home pages of the ScalarDL 3.8 and 3.9 docs to help guide users to certain docs in each section.

This PR also fixes some related translations and adds "Unsupported" wording to the 3.7 docs in the dropdown menu when on Japanese docs. 

## Related issues and/or PRs

N/A

## Changes made

- Added Card components for ScalarDL 3.8 and 3.9.
- Revised **index.mdx** for 3.8 and 3.9 to use the Card components.
- Marked 3.7 as out of support in the dropdown menu for the Japanese documentation.
- Updated side navigation according to comments in a [PR about sidebar navigation wording for the ScalarDB docs site](https://github.com/scalar-labs/docs-scalardb/pull/762).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A