### PR TITLE
Add glossary to Japanese sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -648,6 +648,11 @@ const sidebars = {
           label: '実装',
         },
         {
+          "type": "doc",
+          "id": "glossary",
+          "label": "用語集",
+        },
+        {
           type: 'doc',
           id: 'requirements',
           label: '要件',

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -591,6 +591,11 @@
         },
         {
           "type": "doc",
+          "id": "glossary",
+          "label": "用語集"
+        },
+        {
+          "type": "doc",
           "id": "requirements",
           "label": "要件"
         },


### PR DESCRIPTION
## Description

This PR adds the glossary to the sidebar navigation for versions 3.10 and 3.9 of the docs in Japanese. The glossary wasn't included in those versions because we recently changed how we structure sidebars.

## Related issues and/or PRs

Changed how we structure sidebars in https://github.com/scalar-labs/docs-scalardl/pull/597.

## Changes made

- Added the glossary to version 3.10 and 3.9 of the Japanese docs sidebar navigation.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A