### PR TITLE
Add syntax highlight for additional coding languages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -409,6 +409,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
+        additionalLanguages: ['csharp', 'docker', 'java', 'json', 'log', 'properties', 'python', 'scala', 'sql', 'toml'],
       },
       announcementBar: {
         id: 'new_version',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -409,7 +409,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
-        additionalLanguages: ['csharp', 'docker', 'java', 'json', 'log', 'properties', 'python', 'scala', 'sql', 'toml'],
+        additionalLanguages: ['csharp', 'docker', 'gradle', 'java', 'json', 'log', 'properties', 'python', 'scala', 'shell-session', 'sql', 'toml'],
       },
       announcementBar: {
         id: 'new_version',


### PR DESCRIPTION
## Description

This PR adds syntax highlighting for additional coding languages. 

> [!NOTE]
>
> - By default, Docusaurus includes a limited number of languages that have syntax highlighting, [as described in their documentation](https://docusaurus.io/docs/3.5.2/markdown-features/code-blocks#supported-languages).
> - When testing syntax-highlighting feature, I tried to apply `shell-session`, which shows as being the common language/syntax supported in [Prism](https://prismjs.com/#supported-languages) and in Docusaurus after the site is built (in **node_modules/prismjs/components/prism-shell-session.js**), but I didn't see any changes, visually, to the code blocks.

## Related issues and/or PRs

N/A

## Changes made

- Added the following languages to the Docusaurus configuration file, which enables syntax highlighting:
  - `csharp`
  - `docker`
  - `gradle`
  - `java`
  - `json`
  - `log`
  - `properties`
  - `python`
  - `scala`
  - `shell-session`
  - `sql`
  - `toml`

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A