### PR TITLE
Display `Enterprise Standard` and `Enterprise Premium` edition tags as a single `Enterprise` edition tag

### DIFF
--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -29,6 +29,24 @@ export default function DocVersionBadge({
   const {tags} = metadata;
 
   const versionMetadata = useDocsVersion();
+
+  // Normalize and deduplicate Enterprise tags.
+  const normalizedTags = Array.from(
+    new Map(
+      tags.map(tag => [
+        tag.label === 'Enterprise Standard' || tag.label === 'Enterprise Premium'
+          ? 'Enterprise'
+          : tag.label, // Use "Enterprise" as the key for both variants.
+        {
+          ...tag,
+          label: 'Enterprise Standard' === tag.label || 'Enterprise Premium' === tag.label
+            ? 'Enterprise'
+            : tag.label,
+        },
+      ])
+    ).values()
+  );
+
   if (versionMetadata.badge) {
     return (
       <span
@@ -48,7 +66,7 @@ export default function DocVersionBadge({
             ThemeClassNames.docs.docFooterTagsRow,
           )}>
           <div className="col">
-            <TagsListInline tags={tags} />
+            <TagsListInline tags={normalizedTags} />
             <a href="https://scalar-labs.com/pricing/" target="_blank" className="fa-solid fa-circle-question tooltip"><FontAwesomeIcon icon={faCircleQuestion} size="lg" /><span className="tooltiptext">Features and pricing</span></a>
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR makes the tags `Enterprise Standard` and `Enterprise Premium`, which are in the Markdown front-matter properties in some Helm Charts and Kubernetes docs, appear as `Enterprise` on the docs site. 

We need to implement this function because some docs apply to the Enterprise editions of ScalarDB and ScalarDL, but since ScalarDB has **Enterprise Standard** and **Enterprise Premium** editions and ScalarDL only has an **Enterprise** edition, we need to show only the `Enterprise` tag on the ScalarDL docs site.

## Related issues and/or PRs

- https://github.com/scalar-labs/docs-scalardl/pull/685

## Changes made

- Modified the **DocVersionBadge** component to display a single `Enterprise` tag in docs that have `Enterprise Standard` and/or `Enterprise Premium` tags in the Markdown front-matter properties.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A