### PR TITLE
Move ScalarDL Auditor getting-started doc to `Develop` category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -72,11 +72,6 @@ const sidebars = {
           id: 'getting-started',
           label: 'Run a Contract Through ScalarDL Ledger',
         },
-        {
-          type: 'doc',
-          id: 'getting-started-auditor',
-          label: 'Run a Contract Through ScalarDL Ledger and Auditor',
-        },
       ],
     },
     {
@@ -107,6 +102,11 @@ const sidebars = {
               label: 'ScalarDL Java Client SDK',
             },
           ],
+        },
+        {
+          type: 'doc',
+          id: 'getting-started-auditor',
+          label: 'Run a Contract Through ScalarDL Ledger and Auditor',
         },
         {
           type: 'doc',
@@ -674,11 +674,6 @@ const sidebars = {
           id: 'getting-started',
           label: 'ScalarDL Ledger を通じてコントラクトを実行',
         },
-        {
-          type: 'doc',
-          id: 'getting-started-auditor',
-          label: 'ScalarDL Ledger と Auditor を通じてコントラクトを実行',
-        },
       ],
     },
     {
@@ -709,6 +704,11 @@ const sidebars = {
               label: 'ScalarDL Java Client SDK',
             },
           ],
+        },
+        {
+          type: 'doc',
+          id: 'getting-started-auditor',
+          label: 'ScalarDL Ledger と Auditor を通じてコントラクトを実行',
         },
         {
           type: 'doc',

--- a/versioned_sidebars/version-3.8-sidebars.json
+++ b/versioned_sidebars/version-3.8-sidebars.json
@@ -22,8 +22,7 @@
       "label": "Getting Started",
       "collapsible": true,
       "items": [
-        "getting-started",
-        "getting-started-auditor"
+        "getting-started"
       ]
     },
     {
@@ -47,6 +46,7 @@
             "scalardl-java-client-sdk/README"
           ]
         },
+        "getting-started-auditor",
         "data-modeling",
         "how-to-write-applications",
         "configurations",

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -51,11 +51,6 @@
           "type": "doc",
           "id": "getting-started",
           "label": "Run a Contract Through ScalarDL Ledger"
-        },
-        {
-          "type": "doc",
-          "id": "getting-started-auditor",
-          "label": "Run a Contract Through ScalarDL Ledger and Auditor"
         }
       ]
     },
@@ -87,6 +82,11 @@
               "label": "ScalarDL Java Client SDK"
             }
           ]
+        },
+        {
+          "type": "doc",
+          "id": "getting-started-auditor",
+          "label": "Run a Contract Through ScalarDL Ledger and Auditor"
         },
         {
           "type": "doc",
@@ -615,11 +615,6 @@
           "type": "doc",
           "id": "getting-started",
           "label": "ScalarDL Ledger を通じてコントラクトを実行"
-        },
-        {
-          "type": "doc",
-          "id": "getting-started-auditor",
-          "label": "ScalarDL Ledger と Auditor を通じてコントラクトを実行"
         }
       ]
     },
@@ -651,6 +646,11 @@
               "label": "ScalarDL Java Client SDK"
             }
           ]
+        },
+        {
+          "type": "doc",
+          "id": "getting-started-auditor",
+          "label": "ScalarDL Ledger と Auditor を通じてコントラクトを実行"
         },
         {
           "type": "doc",


### PR DESCRIPTION
## Description

This PR moves the ScalarDL Auditor getting-started doc from the **Getting Started** category to the **Deploy** category. Since the contents of the getting started are a bit advanced, we've decided to move it to the **Develop** section.

## Related issues and/or PRs

N/A

## Changes made

- Moved the ScalarDL Auditor getting-started doc to the **Develop** section of the sidebar navigation for versions under Maintenance Support (3.10, 3.9, and 3.8).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A