### PR TITLE
Add support dropdown menu to right-hand sidebar of pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@fortawesome/react-fontawesome": "0.2.2",
         "@mdx-js/react": "^3.0.0",
         "@microsoft/clarity": "1.0.0",
+        "@typebot.io/react": "0.3.47",
         "clsx": "^2.0.0",
         "docusaurus-lunr-search": "^3.3.2",
         "docusaurus-plugin-image-zoom": "^2.0.0",
@@ -4774,6 +4775,26 @@
       "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@typebot.io/js": {
+      "version": "0.3.46",
+      "resolved": "https://registry.npmjs.org/@typebot.io/js/-/js-0.3.46.tgz",
+      "integrity": "sha512-CMTLNyQCtVnJEeod+AB4Xp7X4tKOxxtk11hnPkWbV70KoVgGEPDIu+sN4vAOUw1ZmebXIbWVGC+0F3vOAX1/lA==",
+      "license": "FSL-1.1-ALv2"
+    },
+    "node_modules/@typebot.io/react": {
+      "version": "0.3.47",
+      "resolved": "https://registry.npmjs.org/@typebot.io/react/-/react-0.3.47.tgz",
+      "integrity": "sha512-JcOSWlpF96m3H3NWquDXz8ks8DvqB7iTGNuiWWRBPbxsQbRsrIZevO69MLCDfE8EuRDogCQhgKxCtDYuxjxceQ==",
+      "license": "FSL-1.1-ALv2",
+      "dependencies": {
+        "@typebot.io/js": "0.3.46",
+        "react": "18.2.0"
+      },
+      "peerDependencies": {
+        "@typebot.io/js": "0.3.22",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@types/acorn": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
     "react-cookie-consent": "9.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "@typebot.io/react": "0.3.47"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.7.0",

--- a/src/components/Support/AssistantModal.tsx
+++ b/src/components/Support/AssistantModal.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Standard } from "@typebot.io/react";
+
+function AssistantModal({ isOpen, onClose }) {
+  if (!isOpen) return null; // Prevent modal from rendering when isOpen is false.
+
+  // Get the current page URL.
+  const currentUrl = window.location.href;
+
+  // Check if the user is on the Japanese documentation page.
+  const isJapanese = currentUrl.includes("/ja-jp");
+
+  return (
+    <div className="modal" style={styles.modal}>
+      <div className="modal-content" style={styles.modalContent}>
+        {/* Close the button. */}
+        <span className="close" onClick={onClose} style={styles.closeButton}>
+          &times;
+        </span>
+
+        {/* Conditionally render the Typebot based on language. */}
+        <Standard
+          typebot={isJapanese
+            ? "ja-jp-scalar-docs-ai-assistant-for-scalar-membership-program-members-201712"
+            : "en-us-scalar-docs-ai-assistant-for-scalar-membership-program-members-201712"
+          }
+          style={{ width: "100%", height: "600px" }}
+          prefilledVariables={{
+            "Current page URL": `${currentUrl}`, // Pass page URL as a query parameter.
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  modal: {
+    display: "block",
+    position: "fixed",
+    zIndex: 1000,
+    left: 0,
+    top: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+  },
+  modalContent: {
+    backgroundColor: "#fff",
+    margin: "10% auto",
+    padding: "20px",
+    borderRadius: "10px",
+    width: "90%",
+    maxWidth: "900px",
+    position: "relative", // Allow absolute positioning of the close button.
+  },
+  closeButton: {
+    position: "absolute",
+    top: "10px",
+    right: "20px",
+    fontSize: "30px",
+    fontWeight: "bold",
+    cursor: "pointer",
+    color: "#333",
+    backgroundColor: "transparent",
+    border: "none",
+    padding: "0",
+    zIndex: 1100, // Ensure the close button is above the modal content.
+  },
+};
+
+export default AssistantModal;

--- a/src/components/Support/SupportDropdownMenu.tsx
+++ b/src/components/Support/SupportDropdownMenu.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect, useRef, lazy, Suspense, MouseEvent } from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import { useLocation } from "@docusaurus/router";
+
+// Lazy-load AssistantModal.
+const AssistantModal = lazy(() => import('./AssistantModal'));
+
+const SupportDropdownMenu: React.FC = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [storedUrl, setStoredUrl] = useState<string | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const location = useLocation();
+
+  // Get document metadata from Docusaurus.
+  const { metadata } = useDoc();
+  const docTitle: string = metadata?.title || "Issue with documentation page";
+
+  // Detect the language based on the URL path.
+  const isJapanese: boolean = location.pathname.startsWith("/ja-jp");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const currentUrl = `https://scalardl.scalar-labs.com${location.pathname}`;
+      localStorage.setItem("currentUrl", currentUrl);
+
+      const savedUrl = localStorage.getItem("currentUrl");
+      if (savedUrl) {
+        setStoredUrl(savedUrl);
+      }
+    }
+  }, [location]);
+
+  const toggleDropdown = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const openModal = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    setIsModalOpen(true);
+    setIsOpen(false);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleSupportClick = () => {
+    if (typeof window !== "undefined") {
+      const finalUrl = storedUrl || `https://scalardl.scalar-labs.com${location.pathname}`;
+      const reportUrl = `https://support.scalar-labs.com/hc/ja/requests/new?ticket_form_id=8641483507983&tf_11847415366927=${encodeURIComponent(finalUrl)}`;
+
+      window.open(reportUrl, "_blank");
+    }
+  };
+
+  const githubIssueUrl: string = typeof window !== "undefined" ? (() => {
+    const repoUrl = "https://github.com/scalar-labs/docs-scalardl/issues/new";
+    const issueTitle = encodeURIComponent(
+      isJapanese ? `フィードバック: \`${docTitle}\` ページ` : `Feedback: \`${docTitle}\` page`
+    );
+
+    const issueBody = encodeURIComponent(
+      isJapanese
+        ? `**ドキュメントページの URL:** ${window.location.href.replace(/#.*$/, '')}
+
+## 期待される動作
+
+どのような動作を期待しましたか？
+
+## 問題の説明
+
+問題の内容をわかりやすく説明してください。
+
+### 再現手順 (該当する場合)
+
+問題を再現できる場合、手順を記載してください。
+
+### スクリーンショット (該当する場合)
+
+該当する場合は、スクリーンショットを添付してください。
+`
+    : `**Documentation page URL:** ${window.location.href.replace(/#.*$/, '')}
+
+## Expected behavior
+
+What did you expect to happen?
+
+## Describe the problem
+
+Please provide a clear and concise description of what the issue is.
+
+### Steps to reproduce (if applicable)
+
+If the issue is reproducible, please list the steps to reproduce it.
+
+### Screenshots (if applicable)
+
+If applicable, add screenshots to help explain your problem.
+`
+    );
+
+    const issueUrl = `${repoUrl}?title=${issueTitle}&body=${issueBody}&labels=documentation`;
+
+    console.log("GitHub Issue URL: ", issueUrl);  // Debugging line
+
+    return issueUrl;
+  })() : "#";
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent | Event) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <div className="supportDropdown" ref={dropdownRef}>
+      <button className="supportDropBtn" onMouseOver={toggleDropdown}>
+        {isJapanese ? "何かお困りですか?" : "Need some help?"}<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="m12 16l-6-6h12z"/></svg>
+      </button>
+
+        <div className="supportDropdownContent">
+          <div>
+            <a href="#" onClick={handleSupportClick} rel="noopener noreferrer">
+              <b>{isJapanese ? "テクニカルサポートに問い合わせ" : "Contact technical support"}</b><br />
+              {isJapanese ? "商用ライセンスをご契約のお客様のみご利用いただけます。" : "Available only to customers with a commercial license."}
+            </a>
+          </div>
+          <hr />
+          {/* <a href="https://stackoverflow.com/questions/tagged/scalardl" target="_blank" rel="noopener noreferrer">
+            <b>{isJapanese ? "Stack Overflow をチェック" : "Check Stack Overflow"}</b><br />
+            {isJapanese ? "すべてのユーザーがご利用いただけます。" : "Available to all users."}
+          </a>
+          <hr /> */}
+          <a href="#" onClick={openModal}>
+            <b>{isJapanese ? "AI に聞く (試験運用中)" : "Ask AI (experimental)"}</b><br />
+            {isJapanese ? "Scalar Membership Programにご参加の方のみご利用いただけます。" : "Available only to members of the Scalar Membership Program."}
+          </a>
+          <hr />
+          <a href={githubIssueUrl} target="_blank" rel="noopener noreferrer">
+            <b>{isJapanese ? "ドキュメントの問題を報告" : "Report doc issue"}</b><br />
+            {isJapanese ? "このページについて何かお気づきの点がありましたら、こちらから報告いただけます。" : "If you have any feedback about this page, please submit an issue."}
+          </a>
+        </div>
+
+      {isModalOpen && (
+        <Suspense fallback={<div>Loading...</div>}>
+          <AssistantModal isOpen={isModalOpen} onClose={closeModal} />
+        </Suspense>
+      )}
+    </div>
+  );
+};
+
+export default SupportDropdownMenu;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -318,7 +318,7 @@ html[data-theme="dark"] .tooltip-glossary {
 }
 
 .supportDropdownContent a {
-  color: black;
+  color: var(--ifm-dropdown-link-color);
   display: block;
   margin: 4px 10px;
   padding: 4px 10px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -245,3 +245,108 @@ html[data-theme="dark"] .tooltip-glossary {
     width: 333px !important;
   }
 }
+
+/* Support button and dropdown */
+.supportDropdown {
+  display: inline-block;
+  position: relative;
+}
+
+.supportDropdownContent {
+  background-color: #f9f9f9;
+  border-radius: 8px;
+  box-shadow: var(--ifm-global-shadow-md);
+  color: var(--ifm-color-emphasis-700);
+  font-size: 14px;
+  min-width: 303px;
+  opacity: 0;
+  overflow: hidden;
+  padding: 8px 0px;
+  position: absolute;
+  right: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+  visibility: hidden;
+  z-index: 1;
+}
+
+.supportDropdown:hover .supportDropdownContent {
+  visibility: visible;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.supportDropdownContent {
+  transition-delay: 0.1s;
+}
+
+.supportDropBtn {
+  align-items: center;
+  background-color: inherit;
+  border: 0;
+  border-radius: var(--ifm-badge-border-radius);
+  color: var(--ifm-navbar-link-color);
+  cursor: pointer;
+  display: flex;
+  font-family: var(--ifm-font-family-base);
+  font-size: 14.5px;
+  font-weight: var(--ifm-font-weight-semibold);
+  justify-content: space-between;
+  min-width: 145px;
+  padding: 6px 0;
+  text-align: left;
+  z-index: 1;
+}
+
+.supportDropBtn svg { /* Keep dropdown open when moving the mouse between text and icon. */
+  pointer-events: none;
+}
+
+.supportDropdown:hover .supportDropBtn {
+  color: var(--ifm-color-primary);
+}
+
+@media (max-width: 996px) {
+  .supportDropBtn {
+    font-size: 15px;
+  }
+  .supportDropdownContent {
+    font-size: 15px;
+    left: 0;
+    min-width: 320px;
+  }
+}
+
+.supportDropdownContent a {
+  color: black;
+  display: block;
+  margin: 4px 10px;
+  padding: 4px 10px;
+  text-decoration: none;
+}
+
+.supportDropdownContent a:hover {
+  background-color: var(--ifm-dropdown-hover-background-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+html[data-theme="dark"] .supportDropBtn {
+  background-color: inherit;
+  border: 0;
+  color: #f9f9f9;
+}
+
+html[data-theme="dark"] .supportDropdownContent {
+  background-color: var(--ifm-dropdown-background-color);
+
+  a {
+    color: #f9f9f9;
+  }
+}
+
+hr {
+  text-align: center;
+  margin: auto;
+  max-width: 91%;
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,64 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {useWindowSize} from '@docusaurus/theme-common';
+import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import ContentVisibility from '@theme/ContentVisibility';
+import type {Props} from '@theme/DocItem/Layout';
+
+import styles from './styles.module.css';
+
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const {frontMatter, toc} = useDoc();
+  const windowSize = useWindowSize();
+
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+
+  const desktop =
+    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
+      <DocItemTOCDesktop />
+    ) : undefined;
+
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+
+export default function DocItemLayout({children}: Props): ReactNode {
+  const docTOC = useDocTOC();
+  const {metadata} = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        <ContentVisibility metadata={metadata} />
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -48,6 +48,12 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
   const hideTOC = frontMatter.hide_table_of_contents;
   const windowSize = useWindowSize();
 
+  // Check if the current page is the home page or a version homepage.
+  const isHomePage = metadata.permalink === '/docs/latest/' || 
+                     /^\/docs\/\d+\.\d+\/$/.test(metadata.permalink) || 
+                     metadata.permalink === '/ja-jp/docs/latest/' || 
+                     /^\/ja-jp\/docs\/\d+\.\d+\/$/.test(metadata.permalink);
+
   return (
     <div className="row">
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
@@ -57,7 +63,7 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
-            {windowSize === 'mobile' && (
+            {windowSize === 'mobile' && !isHomePage && (
               <div style={{ display: 'flex', justifyContent: 'left', marginBottom: '1rem' }}>
                 <SupportDropdownMenu />
               </div>
@@ -73,9 +79,11 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
       {!hideTOC && windowSize !== 'mobile' && (
         <div className="col col--3" style={{ position: "relative" }}>
           <div style={{ position: "sticky", top: "80px", zIndex: 1 }}>
-            <div style={{ display: 'flex', justifyContent: 'flex-start', padding: '0px 17px', right: '0' }}>
-              <SupportDropdownMenu />
-            </div>
+            {!isHomePage && (
+              <div style={{ display: 'flex', justifyContent: 'flex-start', padding: '0px 17px', right: '0' }}>
+                <SupportDropdownMenu />
+              </div>
+            )}
             {docTOC.desktop}
           </div>
         </div>

--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -1,7 +1,8 @@
-import React, {type ReactNode} from 'react';
+import SupportDropdownMenu from '../../../components/Support/SupportDropdownMenu';
+import React from 'react';
 import clsx from 'clsx';
-import {useWindowSize} from '@docusaurus/theme-common';
-import {useDoc} from '@docusaurus/plugin-content-docs/client';
+import { useWindowSize } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import DocItemPaginator from '@theme/DocItem/Paginator';
 import DocVersionBanner from '@theme/DocVersionBanner';
 import DocVersionBadge from '@theme/DocVersionBadge';
@@ -11,37 +12,42 @@ import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
 import DocItemContent from '@theme/DocItem/Content';
 import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
-import type {Props} from '@theme/DocItem/Layout';
 
 import styles from './styles.module.css';
 
-/**
- * Decide if the toc should be rendered, on mobile or desktop viewports
- */
-function useDocTOC() {
-  const {frontMatter, toc} = useDoc();
-  const windowSize = useWindowSize();
+// Define the type for the useDocTOC return value.
+interface DocTOC {
+  hidden: boolean;
+  mobile?: JSX.Element;
+  desktop?: JSX.Element;
+}
 
+// Type for the DocItemLayout props
+interface DocItemLayoutProps {
+  children: React.ReactNode;
+}
+
+// Hook to handle the Table of Contents visibility and rendering
+function useDocTOC(): DocTOC {
+  const { frontMatter, toc } = useDoc();
+  const windowSize = useWindowSize();
   const hidden = frontMatter.hide_table_of_contents;
   const canRender = !hidden && toc.length > 0;
 
-  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
-
-  const desktop =
-    canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? (
-      <DocItemTOCDesktop />
-    ) : undefined;
-
   return {
     hidden,
-    mobile,
-    desktop,
+    mobile: canRender ? <DocItemTOCMobile /> : undefined,
+    desktop: canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? <DocItemTOCDesktop /> : undefined,
   };
 }
 
-export default function DocItemLayout({children}: Props): ReactNode {
+// DocItemLayout component
+const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
   const docTOC = useDocTOC();
-  const {metadata} = useDoc();
+  const { metadata, frontMatter } = useDoc();
+  const hideTOC = frontMatter.hide_table_of_contents;
+  const windowSize = useWindowSize();
+
   return (
     <div className="row">
       <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
@@ -51,6 +57,11 @@ export default function DocItemLayout({children}: Props): ReactNode {
           <article>
             <DocBreadcrumbs />
             <DocVersionBadge />
+            {windowSize === 'mobile' && (
+              <div style={{ display: 'flex', justifyContent: 'left', marginBottom: '1rem' }}>
+                <SupportDropdownMenu />
+              </div>
+            )}
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>
             <DocItemFooter />
@@ -58,7 +69,19 @@ export default function DocItemLayout({children}: Props): ReactNode {
           <DocItemPaginator />
         </div>
       </div>
-      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+
+      {!hideTOC && windowSize !== 'mobile' && (
+        <div className="col col--3" style={{ position: "relative" }}>
+          <div style={{ position: "sticky", top: "80px", zIndex: 1 }}>
+            <div style={{ display: 'flex', justifyContent: 'flex-start', padding: '0px 17px', right: '0' }}>
+              <SupportDropdownMenu />
+            </div>
+            {docTOC.desktop}
+          </div>
+        </div>
+      )}
     </div>
   );
-}
+};
+
+export default DocItemLayout;

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a support dropdown menu to the right-hand sidebar of pages, above the table of contents on the docs site. The support dropdown menu includes the links to the following:

- `Contact technical support`
  - This link directs visitors to a form on the Scalar technical support portal, where they can submit an issue to receive technical support. 
    - Because of a limitation with the support service platform, a link to the page cannot be added to the form unless the visitor is already logged in to the technical support portal.
    - If the visitor is not logged in, they will still be taken to the form to submit an issue, but the URL will not be prefilled out.
  - Technical support is only for customers with a commercial license.
- `Ask AI (experimental)`
  - This link opens a modal window that contains the Scalar docs AI assistant.
  - The AI assistant is only for members of the Scalar Membership Program.
- `Report doc issue`
  - This link directs visitors to the GitHub issues page.
  - In that issue is a template for visitors to fill out.
      - If the issue is reported from a page in English, the template will be in English. 
      - If the issue is reported from a page in Japanese, the template will be in Japanese.
    - Any visitor can submit an issue about a doc.

> [!NOTE]
> 
> - The support dropdown menu doesn't appear on the home page because doing so doesn't provide much value (We want to encourage visitors to navigate the docs after visiting the home page). We'll be updating the home page in the future, so we can think about if we actually want to include it.

## Related issues and/or PRs

N/A

## Changes made

- [Swizzled](https://docusaurus.io/docs/swizzling) the `Layout` component, which contains the table of contents, and added links for the following:
  - `Contact technical support`
  - `Ask AI (experimental)` (modal)
  - `Report doc issue`
- For the `Ask AI (experimental)` modal, created `AssistantModal.tsx` and implemented the AI assistant based on the [Typebot deployment method](https://docs.typebot.io/deploy/web/react) by using the `@typebot.io/react` npm package.
- Styled the support button and links to match the look and feel of similar buttons and dropdown menus in Docusaurus.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

To see the support dropdown menu in the staged version of the docs site, please see the [autogenerated comment from Netlify](https://github.com/scalar-labs/docs-scalardl/pull/733#issuecomment-2728264325) in this PR.