### PR TITLE
Update announcement to mention ScalarDL Ledger becoming open source

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -416,8 +416,8 @@ const config = {
       announcementBar: {
         id: 'new_version',
         content:
-          '<b>Announcing the release of ScalarDL 3.10!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.',
-          // '<b>Announcing the release of ScalarDL X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.<b>',
+          '<b>🎊ScalarDL Ledger, the ledger database middleware component of ScalarDL, is now open-sourced under Apache License 2.0! To try it out, see <a target="_self" rel="noopener noreferrer" href="/docs/latest/getting-started">Get Started with ScalarDL Ledger</a>.</b>',
+          // '<b>Announcing the release of ScalarDL X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" rel="noopener noreferrer" href="/docs/latest/releases/release-notes">release notes</a>.</b>',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,


### PR DESCRIPTION
## Description

This PR updates the announcement at the top of the docs site to mention ScalarDL Ledger becoming open source.

## Related issues and/or PRs

- ScalarDL Ledger open-source code added in https://github.com/scalar-labs/scalardl/pull/69.

## Changes made

- Changed the announcement from the release of ScalarDL 3.10 to ScalarDL Ledger being open-sourced.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A