### PR TITLE
Fix issue with preview image not showing correctly when sharing home page on social media

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 displayed_sidebar: docsEnglish
+image: img/scalardl-social-card-preview.png
 ---
 
 # ScalarDL

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,5 +1,6 @@
 ---
 displayed_sidebar: docsJapanese
+image: img/scalardl-social-card-preview.png
 ---
 
 # ScalarDL

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/index.mdx
@@ -1,6 +1,10 @@
+---
+image: img/scalardl-social-card-preview.png
+---
+
 # ScalarDL
 
-import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.9';
+import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/ja-jp/3.8';
 
 ScalarDL は、正確性、スケーラビリティ、およびデータベース不可知性を実現する、トランザクショナルデータベースシステム用のスケーラブルで実用的なビザンチン故障検出ミドルウェアです。
 

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/index.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/index.mdx
@@ -1,5 +1,6 @@
 ---
 displayed_sidebar: docsJapanese
+image: img/scalardl-social-card-preview.png
 ---
 
 # ScalarDL

--- a/versioned_docs/version-3.8/index.mdx
+++ b/versioned_docs/version-3.8/index.mdx
@@ -1,3 +1,7 @@
+---
+image: img/scalardl-social-card-preview.png
+---
+
 # ScalarDL
 
 import { CardRowAbout, CardRowGettingStarted, CardRowSamples, CardRowDevelop, CardRowDeploy, CardRowManage, CardRowReference } from '/src/components/Cards/3.8';

--- a/versioned_docs/version-3.9/index.mdx
+++ b/versioned_docs/version-3.9/index.mdx
@@ -1,5 +1,6 @@
 ---
 displayed_sidebar: docsEnglish
+image: img/scalardl-social-card-preview.png
 ---
 
 # ScalarDL


### PR DESCRIPTION
## Description

This PR fixes an issue with the social card preview not showing when sharing the home page on social media platforms that show site preview images.

For some reason, the social card image that we added to **docusaurus.config.js** in #738 isn't being applied when sharing the home page. To work around this, we can manually set the image this way, according to the [Markdown front-matter section in the Docusaurus docs](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter).

## Related issues and/or PRs

- #738 

## Changes made

- Added the social card preview to the front-matter metadata of the home page.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A