### PR TITLE
Add function to generate log file that contains broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+brokenLinks.log
 
 # Gradle build files
 .gradle

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,8 @@ const config = {
   projectName: 'docs-scalardl', // Usually your repo name.
 
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenMarkdownLinks: 'ignore',
+  onBrokenAnchors: 'ignore',
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build && node scripts/generate-glossary-json.js",
+    "build": "docusaurus build 2>&1 | tee brokenLinks.log && node scripts/filter-broken-link-warnings.js && node scripts/generate-glossary-json.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/filter-broken-link-warnings.js
+++ b/scripts/filter-broken-link-warnings.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+
+const logFile = "brokenMarkdownLinks.log";
+
+// Read the full log file
+fs.readFile(logFile, "utf8", (err, data) => {
+  if (err) {
+    console.error("Error reading log file:", err);
+    process.exit(1);
+  }
+
+  // Define the prefixes to filter
+  const prefixes = [
+    "- Broken link on source page path",
+    "   -> linking to "
+  ];
+
+  // Filter lines that start with any of the specified prefixes
+  const filteredLines = data
+    .split("\n")
+    .filter((line) => prefixes.some((prefix) => line.startsWith(prefix)));
+
+  // Overwrite the log file with only the filtered lines
+  fs.writeFile(logFile, filteredLines.join("\n"), "utf8", (err) => {
+    if (err) {
+      console.error("Error writing filtered log file:", err);
+      process.exit(1);
+    }
+    console.log(`Filtered broken link warnings saved to ${logFile}`);
+  });
+});

--- a/scripts/filter-broken-link-warnings.js
+++ b/scripts/filter-broken-link-warnings.js
@@ -1,26 +1,47 @@
 const fs = require("fs");
+const path = require("path");
 
-const logFile = "brokenMarkdownLinks.log";
+// Paths
+const logFile = "brokenLinks.log";
+const unsupportedVersionsFile = path.join(process.cwd(), "src", "pages", "unsupported-versions.mdx");
 
-// Read the full log file
+// Read unsupported versions from the MDX file.
+let unsupportedVersions = [];
+try {
+  const mdxContent = fs.readFileSync(unsupportedVersionsFile, "utf8");
+  // Extract unsupported version numbers (like 3.7, 3.6, etc.).
+  unsupportedVersions = Array.from(mdxContent.matchAll(/ScalarDL (\d+\.\d+)/g), match => match[1]);
+} catch (err) {
+  console.error("Error reading unsupported versions file:", err);
+  process.exit(1);
+}
+
+if (unsupportedVersions.length === 0) {
+  console.log("No unsupported versions found. Exiting.");
+  process.exit(0);
+}
+
+// Define the prefixes to filter for broken links.
+const prefixes = [
+  "- Broken link on source page path",
+  "   -> linking to "
+];
+
+// Read the log file and filter lines based on unsupported versions.
 fs.readFile(logFile, "utf8", (err, data) => {
   if (err) {
     console.error("Error reading log file:", err);
     process.exit(1);
   }
 
-  // Define the prefixes to filter
-  const prefixes = [
-    "- Broken link on source page path",
-    "   -> linking to "
-  ];
-
-  // Filter lines that start with any of the specified prefixes
   const filteredLines = data
     .split("\n")
-    .filter((line) => prefixes.some((prefix) => line.startsWith(prefix)));
+    .filter((line) =>
+      prefixes.some((prefix) => line.startsWith(prefix)) &&
+      !unsupportedVersions.some((version) => line.includes(`/docs/${version}/`)) // Exclude unsupported versions.
+    );
 
-  // Overwrite the log file with only the filtered lines
+  // Overwrite the log file with filtered lines.
   fs.writeFile(logFile, filteredLines.join("\n"), "utf8", (err) => {
     if (err) {
       console.error("Error writing filtered log file:", err);


### PR DESCRIPTION
## Description

This PR adds a function to generate a log file that contains broken links when building the docs site. This log file is for reference when building the docs site locally. Therefore, we should regularly check for broken links. 

> [!IMPORTANT]
>
> Once all links in versions of docs that are under Maintenance Support have been fixed, we should consider changing `warn` to `throw` so that we can catch broken links immediately, rather than needing to check on a regular basis.

Specifications:

- Setting `onBrokenLinks` to `warn` catches external links, Markdown links, and anchor links, according to [Docusaurus' documentation](https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks).
- Only versions of docs that are under Maintenance Support are added to the output log file.
  - Versions are based on the versions listed in **src/pages/unsupported-versions.mdx**.
- The output log file is ignored when generated.
  - Its contents should be generated and addressed locally, so there's no reason to include it in the build files.

## Related issues and/or PRs

N/A

## Changes made

- Changed the `onBrokenMarkdownLinks` and `on AnchorLinks` options to `ignore` since `onBrokenLinks` is set to `warn` and catches those two types of broken links as well as external links.
- Created a script that lists broken links and their originating pages (versions of docs under Maintenance Support only) into a .log file.
- Added the broken-link log generator to the `build` command in **package.json**.
- Updated the **.gitignore** to exclude the output .log file that contains broken links.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A