### PR TITLE
Fix sidebar showing support button and ToC from appearing on top of zoomed-in images

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -268,7 +268,7 @@ html[data-theme="dark"] .tooltip-glossary {
   transform: translateY(-10px);
   transition: opacity 0.3s ease-out, transform 0.3s ease-out;
   visibility: hidden;
-  z-index: 5; /* Lowered to avoid overlapping with zoomed-in images. */
+  z-index: 1;
 }
 
 .supportDropdown:hover .supportDropdownContent {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -267,7 +267,7 @@ html[data-theme="dark"] .tooltip-glossary {
   transform: translateY(-10px);
   transition: opacity 0.3s ease-out, transform 0.3s ease-out;
   visibility: hidden;
-  z-index: 1;
+  z-index: 5; /* Lowered to avoid overlapping with zoomed-in images. */
 }
 
 .supportDropdown:hover .supportDropdownContent {
@@ -353,4 +353,14 @@ hr {
 
 html[data-theme="dark"] .container img[src$=".png"] { /* Adds a white background to transparent .png images. */
   background-color: #ffffff;
+}
+
+.medium-zoom-overlay {
+  z-index: 15;
+  position: fixed;
+}
+
+.medium-zoom-image {
+  z-index: 20;
+  position: relative;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -56,6 +56,7 @@
 div[class^='announcementBar'] {
   font-size: 1.1rem;
   padding: 20px 0;
+  z-index: 21; /* Ensures the announcement bar stays visible when images are zoomed in on */
 }
 
 /* Home page cards */


### PR DESCRIPTION
## Description

This PR fixes an issue where the sidebar that contains the support button and table of contents (ToC) was appearing on top of zoomed-in images. When clicking on an image, the sidebar that contains the support menu and ToC would appear on top of the zoomed-in image. The addition of the image styles in this PR ensures that the image overlays that sidebar.

## Related issues and/or PRs

- Support button and dropdown added in https://github.com/scalar-labs/docs-scalardl/pull/733.

## Changes made

- Added styles for `.medium-zoom-overlay` and `.medium-zoom-image` to make zoomed-in images appear on top of the sidebar that contains the support button and ToC.
- Adjusted the style for the announcement bar to ensure that it stays visible when an image is zoomed in on. 

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [ ] I have updated the side navigation as necessary. `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes. `N/A`
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.). `N/A`
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published. `N/A`

## Additional notes (optional)

N/A