### PR TITLE
Remove `rel="noopener noreferrer"` from custom Docusaurus components

### DIFF
--- a/src/components/NotificationBell.tsx
+++ b/src/components/NotificationBell.tsx
@@ -98,7 +98,6 @@ const NotificationBell = ({ notifications }) => {
               className={`notification-item ${!notification.read ? 'unread' : ''}`}
               onClick={(e) => handleNotificationClick(notification, e)}
               target={notification.isExternal ? '_blank' : '_self'}
-              rel={notification.isExternal ? 'noopener noreferrer' : undefined}
             >
               {notification.message}
             </a>

--- a/src/components/Support/SupportDropdownMenu.tsx
+++ b/src/components/Support/SupportDropdownMenu.tsx
@@ -104,7 +104,7 @@ const SupportDropdownMenu: React.FC = () => {
   const handleGitHubClick = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     if (githubIssueUrl !== "#") {
-      window.open(githubIssueUrl, "_blank", "noopener,noreferrer");
+      window.open(githubIssueUrl, "_blank");
     } else {
       console.error("GitHub issue URL is not set correctly.");
     }

--- a/src/theme/JavadocLink.js
+++ b/src/theme/JavadocLink.js
@@ -22,7 +22,6 @@ export default function JavadocLink({ packageName, path, className }) {
     <a
       href={`https://javadoc.io/static/com.scalar-labs/${packageName}/${docsClassName}/${path}/${className}.html`}
       target="_blank"
-      rel="noopener noreferrer"
     >
       {className}
     </a>


### PR DESCRIPTION
## Description

This PR removes `rel="noopener noreferrer"` from custom components in Docusaurus so that we can better measure the effectiveness of the support-related links, in-site notification links, and Javadocs links.

## Related issues and/or PRs

N/A

## Changes made

- Removed `rel="noopener noreferrer"` from custom components.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A