### PR TITLE
Remove glossary tooltips version from home pages

### DIFF
--- a/src/components/GlossaryInjector.tsx
+++ b/src/components/GlossaryInjector.tsx
@@ -36,19 +36,11 @@ const GlossaryInjector: React.FC<GlossaryInjectorProps> = ({ children }) => {
       const path = window.location.pathname;
 
       // Check for various version index patterns
-      // English versions
-      if (path.match(/\/docs\/latest\/?$/) ||
-          path.match(/\/docs\/latest\/index(\.html)?/) ||
-          path.match(/\/docs\/[0-9]+\.[0-9]+\/?$/) ||
-          path.match(/\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
-        return true;
-      }
-
-      // Japanese versions
-      if (path.match(/\/ja-jp\/docs\/latest\/?$/) ||
-          path.match(/\/ja-jp\/docs\/latest\/index(\.html)?/) ||
-          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/?$/) ||
-          path.match(/\/ja-jp\/docs\/[0-9]+\.[0-9]+\/index(\.html)?/)) {
+      const localePrefix = '(?:/ja-jp)?'; // Matches either '/ja-jp' or nothing
+      if (path.match(new RegExp(`${localePrefix}/docs/latest/?$`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/latest/index(\\.html)?`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/[0-9]+\\.[0-9]+/?$`)) ||
+          path.match(new RegExp(`${localePrefix}/docs/[0-9]+\\.[0-9]+/index(\\.html)?`))) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

This PR hides glossary tooltips on version home pages by adjusting the glossary injection logic in the GlossaryInjector component accordingly.

## Related issues and/or PRs

N/A

## Changes made

* [`src/components/GlossaryInjector.tsx`](diffhunk://#diff-a29d46fa93159f09bd4e170daa2a60dbb43ca196b88675a769c72468151b0ec2R33-R59): Added the `isVersionIndexPage` function to identify version index pages based on URL patterns for both English and Japanese documentation. Updated the `useEffect` hook to skip glossary injection on these pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A