### PR TITLE
Fix Assistance Support naming in Japanese version of Release Support Policy

### DIFF
--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -26,7 +26,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <th>バージョン</th>
       <th>発売日</th>
       <th>メンテナンスサポート終了日</th>
-      <th>サポートサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
@@ -26,7 +26,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <th>バージョン</th>
       <th>発売日</th>
       <th>メンテナンスサポート終了日</th>
-      <th>サポートサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.4/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.4/releases/release-support-policy.mdx
@@ -19,8 +19,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <th>バージョン</th>
       <th>発売日</th>
-      <th>メンテナンス サポート終了日</th>
-      <th>サポート サポート終了日</th>
+      <th>メンテナンスサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.5/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.5/releases/release-support-policy.mdx
@@ -19,8 +19,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <th>バージョン</th>
       <th>発売日</th>
-      <th>メンテナンス サポート終了日</th>
-      <th>サポート サポート終了日</th>
+      <th>メンテナンスサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.6/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.6/releases/release-support-policy.mdx
@@ -19,8 +19,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <th>バージョン</th>
       <th>発売日</th>
-      <th>メンテナンス サポート終了日</th>
-      <th>サポート サポート終了日</th>
+      <th>メンテナンスサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.7/releases/release-support-policy.mdx
@@ -19,8 +19,8 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <th>バージョン</th>
       <th>発売日</th>
-      <th>メンテナンス サポート終了日</th>
-      <th>サポート サポート終了日</th>
+      <th>メンテナンスサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
@@ -20,7 +20,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <th>バージョン</th>
       <th>発売日</th>
       <th>メンテナンスサポート終了日</th>
-      <th>サポートサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
@@ -26,7 +26,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <th>バージョン</th>
       <th>発売日</th>
       <th>メンテナンスサポート終了日</th>
-      <th>サポートサポート終了日</th>
+      <th>アシスタンスサポート終了日</th>
       <th>延長サポート</th>
     </tr>
   </thead>


### PR DESCRIPTION
## Description

This PR fixes the Japanese versions of the Release Support Policy pages multiple Japanese-language documentation files to correct a translation inconsistency. Specifically, the column header "サポートサポート終了日" or "サポート サポート終了日" was changed to "アシスタンスサポート終了日" for clarity and accuracy.

## Related issues and/or PRs

N/A

## Changes made

- Changed the column header `サポートサポート終了日`/`サポート サポート終了日` to `アシスタンスサポート終了日` in the "Release Support Policy" doc across versions.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A