### PR TITLE
Remove link to Auditor getting started doc; translate intro text on Japanese version home pages

### DIFF
--- a/src/components/Cards/3.10.tsx
+++ b/src/components/Cards/3.10.tsx
@@ -82,8 +82,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['getting-started-auditor'],
-        labels: ['Getting Started with ScalarDL Auditor']
+        links: [''],
+        labels: ['']
       }
     ]
   },

--- a/src/components/Cards/3.11.tsx
+++ b/src/components/Cards/3.11.tsx
@@ -82,8 +82,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['getting-started-auditor'],
-        labels: ['Getting Started with ScalarDL Auditor']
+        links: [''],
+        labels: ['']
       }
     ]
   },

--- a/src/components/Cards/3.9.tsx
+++ b/src/components/Cards/3.9.tsx
@@ -82,8 +82,8 @@ const categories = [
       },
       {
         cell: 2, // Third cell
-        links: ['getting-started-auditor'],
-        labels: ['Getting Started with ScalarDL Auditor']
+        links: [''],
+        labels: ['']
       }
     ]
   },

--- a/src/components/Cards/ja-jp/3.10.tsx
+++ b/src/components/Cards/ja-jp/3.10.tsx
@@ -162,7 +162,7 @@ const CategoryGrid = () => {
       <div className="hero-section">
         <div className="hero-text">
           <h1>ScalarDL</h1>
-          <p>ScalarDL is middleware for realizing a tamper-evident database system by detecting arbitrary faults (that is, Byzantine faults), such as data tampering and malicious attacks, in transactional database systems. It achieves such detection in a scalable and practical way like no other with its novel consensus algorithm.</p>
+          <p>ScalarDL は、トランザクション型データベースシステムにおけるデータ改ざんや悪意のある攻撃などの任意の障害（ビザンチン故障）を検出することで、改ざん検知型データベースシステムを実現するミドルウェアです。独自のコンセンサスアルゴリズムにより、他に類を見ないスケーラブルかつ実用的な方法で障害検出を可能にします。</p>
           {/* <span className="hero-text-additional">
             <p>PLACEHOLDER TEXT</p>
           </span> */}

--- a/src/components/Cards/ja-jp/3.11.tsx
+++ b/src/components/Cards/ja-jp/3.11.tsx
@@ -162,7 +162,7 @@ const CategoryGrid = () => {
       <div className="hero-section">
         <div className="hero-text">
           <h1>ScalarDL</h1>
-          <p>ScalarDL is middleware for realizing a tamper-evident database system by detecting arbitrary faults (that is, Byzantine faults), such as data tampering and malicious attacks, in transactional database systems. It achieves such detection in a scalable and practical way like no other with its novel consensus algorithm.</p>
+          <p>ScalarDL は、トランザクション型データベースシステムにおけるデータ改ざんや悪意のある攻撃などの任意の障害（ビザンチン故障）を検出することで、改ざん検知型データベースシステムを実現するミドルウェアです。独自のコンセンサスアルゴリズムにより、他に類を見ないスケーラブルかつ実用的な方法で障害検出を可能にします。</p>
           {/* <span className="hero-text-additional">
             <p>PLACEHOLDER TEXT</p>
           </span> */}

--- a/src/components/Cards/ja-jp/3.9.tsx
+++ b/src/components/Cards/ja-jp/3.9.tsx
@@ -162,7 +162,7 @@ const CategoryGrid = () => {
       <div className="hero-section">
         <div className="hero-text">
           <h1>ScalarDL</h1>
-          <p>ScalarDL is middleware for realizing a tamper-evident database system by detecting arbitrary faults (that is, Byzantine faults), such as data tampering and malicious attacks, in transactional database systems. It achieves such detection in a scalable and practical way like no other with its novel consensus algorithm.</p>
+            <p>ScalarDL は、トランザクション型データベースシステムにおけるデータ改ざんや悪意のある攻撃などの任意の障害（ビザンチン故障）を検出することで、改ざん検知型データベースシステムを実現するミドルウェアです。独自のコンセンサスアルゴリズムにより、他に類を見ないスケーラブルかつ実用的な方法で障害検出を可能にします。</p>
           {/* <span className="hero-text-additional">
             <p>PLACEHOLDER TEXT</p>
           </span> */}


### PR DESCRIPTION
## Description

This PR removes links to the Auditor getting started doc across the English version home pages and translates mistakenly untranslated home page introduction text on the Japanese version home pages.

## Related issues and/or PRs

N/A

## Changes made

- Removed links to the Auditor getting started doc across the English version home pages.
- Translated home page introduction text from English to Japanese on the Japanese version home pages.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A