### PR TITLE
Mark ScalarDL 3.8 as no longer supported

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -56,11 +56,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>**</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>**</td>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,9 +98,9 @@ const config = {
                 className: '3.9.6',
               },
               "3.8": {
-                label: '3.8',
+                label: '3.8 (unsupported)',
                 path: '3.8',
-                banner: 'none',
+                banner: 'unmaintained',
                 className: '3.8.5',
               },
               "3.7": {

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -60,11 +60,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>**</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>**</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
@@ -46,11 +46,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-support-policy.mdx
@@ -53,11 +53,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "3.8",
+    "message": "3.8 (サポートされていない)",
     "description": "The label for version 3.8"
   },
   "sidebar.docs.category.About ScalarDL": {

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.8/releases/release-support-policy.mdx
@@ -26,11 +26,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
@@ -39,11 +39,11 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-support-policy.mdx
@@ -46,28 +46,28 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
       <td class="version-out-of-support">2022-12-02</td>
       <td class="version-out-of-support">2024-04-18</td>
       <td class="version-out-of-support">2024-10-15</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.6/releases/release-notes#v360">3.6</a>*</td>
       <td class="version-out-of-support">2022-09-22</td>
       <td class="version-out-of-support">2023-12-02</td>
       <td class="version-out-of-support">2024-05-30</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
       <td class="version-out-of-support">2022-08-03</td>
       <td class="version-out-of-support">2023-09-22</td>
       <td class="version-out-of-support">2024-03-20</td>
       <td class="version-out-of-support"><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
       <td class="version-out-of-support">2022-02-22</td>
       <td class="version-out-of-support">2023-08-03</td>
       <td class="version-out-of-support">2024-01-30</td>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-pages/unsupported-versions.mdx
@@ -9,6 +9,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ScalarDL の次のバージョンはサポートされなくなりました。
 
+- [ScalarDL 3.8](/docs/3.8/)
 - [ScalarDL 3.7](/docs/3.7/)
 - [ScalarDL 3.6](/docs/3.6/)
 - [ScalarDL 3.5](/docs/3.5/)

--- a/src/pages/unsupported-versions.mdx
+++ b/src/pages/unsupported-versions.mdx
@@ -5,6 +5,7 @@
 
 The following versions of ScalarDL are no longer supported:
 
+- [ScalarDL 3.8](/docs/3.8/)
 - [ScalarDL 3.7](/docs/3.7/)
 - [ScalarDL 3.6](/docs/3.6/)
 - [ScalarDL 3.5](/docs/3.5/)

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -42,11 +42,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -49,11 +49,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/versioned_docs/version-3.8/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.8/releases/release-support-policy.mdx
@@ -22,11 +22,11 @@ This page describes Scalar's support policy for major and minor version releases
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/versioned_docs/version-3.9/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.9/releases/release-support-policy.mdx
@@ -35,11 +35,11 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a></td>
-      <td>2023-04-19</td>
-      <td>2025-04-05</td>
-      <td>2025-10-02</td>
-      <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.8/releases/release-notes#v380">3.8</a>*</td>
+      <td class="version-out-of-support">2023-04-19</td>
+      <td class="version-out-of-support">2025-04-05</td>
+      <td class="version-out-of-support">2025-10-02</td>
+      <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
       <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>

--- a/versioned_docs/version-3.9/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.9/releases/release-support-policy.mdx
@@ -42,28 +42,28 @@ This page describes Scalar's support policy for major and minor version releases
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.7/releases/release-notes#v370">3.7</a>*</td>
       <td class="version-out-of-support">2022-12-02</td>
       <td class="version-out-of-support">2024-04-18</td>
       <td class="version-out-of-support">2024-10-15</td>
       <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.6/releases/release-notes#v360">3.6</a>*</td>
       <td class="version-out-of-support">2022-09-22</td>
       <td class="version-out-of-support">2023-12-02</td>
       <td class="version-out-of-support">2024-05-30</td>
       <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.5/releases/release-notes#v350">3.5</a>*</td>
       <td class="version-out-of-support">2022-08-03</td>
       <td class="version-out-of-support">2023-09-22</td>
       <td class="version-out-of-support">2024-03-20</td>
       <td class="version-out-of-support"><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>
     <tr>
-      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>**</td>
+      <td class="version-out-of-support"><a href="https://scalardl.scalar-labs.com/docs/3.4/releases/release-notes#v340">3.4</a>*</td>
       <td class="version-out-of-support">2022-02-22</td>
       <td class="version-out-of-support">2023-08-03</td>
       <td class="version-out-of-support">2024-01-30</td>


### PR DESCRIPTION
> [!IMPORTANT]
>
> This PR must be merged on October 2, 2025, when ScalarDL 3.8 is no longer under Assistant Support.

## Description

This PR marks ScalarDL 3.8 as no longer supported since Assistance Support ended on October 2, 2025.

## Related issues and/or PRs

N/A

## Changes made

* Version support policy and documentation updates:
  * Updated all support policy tables in English and Japanese documentation to visually mark ScalarDL 3.8 as unsupported (`class="version-out-of-support"`, added asterisk or double-asterisk, etc.) in files such as `release-support-policy.mdx` for current and versioned docs. [[1]](diffhunk://#diff-ae5caf9936411353d507624660cc84f8e996f8fafbb4c830c27427f3e79238a8L59-R63) [[2]](diffhunk://#diff-a3a80f7d5f52e442dedf28285e5576680e6812b9b9bda60bcf239994544fd175L63-R67) [[3]](diffhunk://#diff-79c77e4e0a8fb7741679bb2643817df9cc948ffb80c1f5f5b7ac9330fbd89941L49-R53) [[4]](diffhunk://#diff-6e803b882ddf3d0b13f47b9a1bd37b31e9612a930b9b617107722f2ae00ed6b8L56-R60) [[5]](diffhunk://#diff-0dc854af61345381e181b1080b2e97499625a4fe31337041e53ac45137968de8L29-R33) [[6]](diffhunk://#diff-187d13f2ad942b72dc08b3d0add87a4c91573d0d0e2cdb60a8f531fd0173ad40L42-R70) [[7]](diffhunk://#diff-4155011972a7f7644c1a4e31f9e4d074706ec09fb53ec2b9068fbed4276a3832L45-R49) [[8]](diffhunk://#diff-15aa91f94a768e0cb1ae68d31c81f29a3be74956cdc42b5b15c6b5b9fcfca46cL52-R56) [[9]](diffhunk://#diff-809099b77ab03252adb4d45871d7ad4ab8b998701c03489829782bc28f501184L25-R29) [[10]](diffhunk://#diff-2141206920372c65511553e5f3d29f4e4a604d0396c8e0c2510fff3814c29ddeL38-R66)
  * Added ScalarDL 3.8 to the lists of unsupported versions in both English and Japanese pages (`unsupported-versions.mdx`). [[1]](diffhunk://#diff-04ff50226c923eb2b032311f987b6344547bbc280ad8558ab3e117a1f9188af8R8) [[2]](diffhunk://#diff-af6bc70dda920515cf0e052e916be883992cb3cd929d963bb87877d21d3bd224R12)
* Configuration and label changes:
  * Updated the Docusaurus config (`docusaurus.config.js`) to display "3.8 (unsupported)" as the label, set its banner to "unmaintained", and updated its CSS class.
  * Changed the Japanese version label for 3.8 to "3.8 (サポートされていない)" in the translation JSON.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A