### PR TITLE
Revise labels for Ledger, HashStore, and TableStore quickstart tutorials in sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -83,17 +83,17 @@ const sidebars = {
         {
           type: 'doc',
           id: 'getting-started',
-          label: 'Run a Contract Through ScalarDL Ledger',
+          label: 'Use Ledger',
         },
         {
           type: 'doc',
           id: 'getting-started-hashstore',
-          label: 'Try Using ScalarDL HashStore',
+          label: 'Use HashStore',
         },
         {
           type: 'doc',
           id: 'getting-started-tablestore',
-          label: 'Try Using ScalarDL TableStore',
+          label: 'Use TableStore',
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -82,11 +82,6 @@ const sidebars = {
       items: [
         {
           type: 'doc',
-          id: 'getting-started',
-          label: 'Use Ledger',
-        },
-        {
-          type: 'doc',
           id: 'getting-started-hashstore',
           label: 'Use HashStore',
         },
@@ -94,6 +89,11 @@ const sidebars = {
           type: 'doc',
           id: 'getting-started-tablestore',
           label: 'Use TableStore',
+        },
+        {
+          type: 'doc',
+          id: 'getting-started',
+          label: 'Use Ledger',
         },
       ],
     },

--- a/sidebars.js
+++ b/sidebars.js
@@ -708,7 +708,7 @@ const sidebars = {
         {
           type: 'doc',
           id: 'getting-started',
-          label: 'ScalarDL Ledger を通じてコントラクトを実行',
+          label: 'Ledger を使用',
         },
       ],
     },

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -666,7 +666,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "ScalarDL Ledger を通じてコントラクトを実行"
+          "label": "Ledger を使用"
         }
       ]
     },

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -63,7 +63,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "Run a Contract Through ScalarDL Ledger"
+          "label": "Use Ledger"
         }
       ]
     },

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -671,7 +671,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "ScalarDL Ledger を通じてコントラクトを実行"
+          "label": "Ledger を使用"
         }
       ]
     },

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -63,7 +63,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "Run a Contract Through ScalarDL Ledger"
+          "label": "Use Ledger"
         }
       ]
     },

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -625,7 +625,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "ScalarDL Ledger を通じてコントラクトを実行"
+          "label": "Ledger を使用"
         }
       ]
     },

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -63,7 +63,7 @@
         {
           "type": "doc",
           "id": "getting-started",
-          "label": "Run a Contract Through ScalarDL Ledger"
+          "label": "Use Ledger"
         }
       ]
     },


### PR DESCRIPTION
## Description

This PR updates the sidebar navigation labels for the Ledger, HashStore, and TableStore "getting started" documentation sections in both English and Japanese for the latest version (3.12). This PR also updates the wording for the Ledger quickstart in previous sidebar navigation versions in both English and Japanese. 

## Related issues and/or PRs

N/A

## Changes made

Sidebar label updates:

- **Main sidebar (`sidebars.js`):**
  - Updated the "getting started" section labels to "Use HashStore", "Use TableStore", and "Use Ledger" for the respective docs, replacing longer, descriptive labels.
  - Updated the Japanese label for the "getting started" section to a shorter form: "Ledger を使用".
- **Versioned sidebars:**
  - For versions 3.9, 3.10, and 3.11, updated the English label from "Run a Contract Through ScalarDL Ledger" to "Use Ledger". [[1]](diffhunk://#diff-7f06a6a231d35d8edc68e8d2582645b12c691c4c4dfb868ea6b41f52e379e42eL66-R66) [[2]](diffhunk://#diff-a47f1cf9deaa704ada2e0b15ae0493aa50acbc1c5f4ad5da34c9f9ee809e7054L66-R66) [[3]](diffhunk://#diff-df98f522edff3dc04b2d0a45f59d0c6cdfbc692ba969c61c750cc0c9019270ecL66-R66)
  - For the same versions, updated the Japanese label from "ScalarDL Ledger を通じてコントラクトを実行" to "Ledger を使用". [[1]](diffhunk://#diff-7f06a6a231d35d8edc68e8d2582645b12c691c4c4dfb868ea6b41f52e379e42eL628-R628) [[2]](diffhunk://#diff-a47f1cf9deaa704ada2e0b15ae0493aa50acbc1c5f4ad5da34c9f9ee809e7054L669-R669) [[3]](diffhunk://#diff-df98f522edff3dc04b2d0a45f59d0c6cdfbc692ba969c61c750cc0c9019270ecL674-R674)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A