### PR TITLE
Add patch version release notes for `3.12.1`, `3.11.1`, `3.10.3`, and `3.9.7`; update className to latest patch versions in Docusaurus config file

### DIFF
--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -11,7 +11,7 @@ This page includes a list of release notes for ScalarDL 3.12.
 
 ## v3.12.0
 
-**Release date:** September 22, 2026
+**Release date:** September 22, 2025
 
 ### Summary
 

--- a/docs/releases/release-notes.mdx
+++ b/docs/releases/release-notes.mdx
@@ -9,6 +9,26 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDL 3.12.
 
+## v3.12.1
+
+**Release date:** October 8, 2025
+
+### Summary
+
+This release has several bug fixes.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed JSON Schema Validator repository and version. ([#277](https://github.com/scalar-labs/scalardl/pull/277))
+
+### Enterprise edition
+
+#### Bug fixes
+
+- Fixed duplicated read lock.
+
 ## v3.12.0
 
 **Release date:** September 22, 2025

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,25 +77,25 @@ const config = {
                 label: '3.12',
                 path: 'latest', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.12.0',
+                className: '3.12.1',
               },
               "3.11": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.11',
                 path: '3.11',
                 banner: 'none',
-                className: '3.11.0',
+                className: '3.11.1',
               },
               "3.10": {
                 label: '3.10',
                 path: '3.10',
                 banner: 'none',
-                className: '3.10.2',
+                className: '3.10.3',
               },
               "3.9": {
                 label: '3.9',
                 path: '3.9',
                 banner: 'none',
-                className: '3.9.6',
+                className: '3.9.7',
               },
               "3.8": {
                 label: '3.8 (unsupported)',

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -15,7 +15,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 ## v3.12.0
 
-**発売日:** 2026年9月22日
+**発売日:** 2025年9月22日
 
 ### まとめ
 

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-notes.mdx
@@ -13,6 +13,26 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDL 3.12 のリリースノートのリストが含まれています。
 
+## v3.12.1
+
+**発売日:** 2025年10月8日
+
+### まとめ
+
+このリリースには、いくつかのバグ修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- JSON Schema Validator のリポジトリとバージョンを修正しました。([#277](https://github.com/scalar-labs/scalardl/pull/277))
+
+### Enterprise edition
+
+#### バグの修正
+
+- 重複した読み取りロックを修正しました。
+
 ## v3.12.0
 
 **発売日:** 2025年9月22日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-notes.mdx
@@ -13,6 +13,33 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDL 3.10 のリリースノートのリストが含まれています。
 
+## v3.10.3
+
+**発売日:** 2025年10月8日
+
+### まとめ
+
+このリリースには、いくつかのバグ修正と脆弱性の修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- 読み取り専用トランザクションの状態管理動作を修正しました。([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- 証明書と秘密鍵のバージョンチェックとメッセージを修正しました。([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- 正しい認証設定のための Ledger 設定検証を修正しました。([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。([#262](https://github.com/scalar-labs/scalardl/pull/262))
+- [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") を修正しました。([#286](https://github.com/scalar-labs/scalardl/pull/286))
+
+### Enterprise edition
+
+#### バグの修正
+
+- 正しい認証設定のための Auditor 設定検証を修正しました。
+- 重複した読み取りロックを修正しました。
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。
+- [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") を修正しました。
+
 ## v3.10.2
 
 **発売日:** 2025年6月20日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-notes.mdx
@@ -13,6 +13,38 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDL 3.11 のリリースノートのリストが含まれています。
 
+## v3.11.1
+
+**発売日:** 2025年10月8日
+
+### まとめ
+
+このリリースには、いくつかの改善、バグ修正、および脆弱性の修正が含まれています。
+
+### Community edition
+
+#### 改善点
+
+- 汎用関数で時間関連のデータ型をサポートしました。([#200](https://github.com/scalar-labs/scalardl/pull/200))
+
+#### バグの修正
+
+- 読み取り専用トランザクションの状態管理動作を修正しました。([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- 証明書と秘密鍵のバージョンチェックとメッセージを修正しました。([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- 正しい認証設定のための Ledger 設定検証を修正しました。([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- テーブル指向の汎用コントラクトでの `IS NULL` と `IS NOT NULL` 条件の処理を修正しました。([#238](https://github.com/scalar-labs/scalardl/pull/238))
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。([#262](https://github.com/scalar-labs/scalardl/pull/262))
+- [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") を修正しました。([#286](https://github.com/scalar-labs/scalardl/pull/286))
+
+### Enterprise edition
+
+#### バグの修正
+
+- 正しい認証設定のための Auditor 設定検証を修正しました。
+- 重複した読み取りロックを修正しました。
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。
+- [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146") を修正しました。
+
 ## v3.11.0
 
 **発売日:** 2025年6月18日

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-notes.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.9/releases/release-notes.mdx
@@ -13,6 +13,31 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
 
 このページには、ScalarDL 3.9 のリリースノートのリストが含まれています。
 
+## v3.9.7
+
+**発売日:** 2025年10月8日
+
+### まとめ
+
+このリリースには、いくつかのバグ修正と脆弱性の修正が含まれています。
+
+### Community edition
+
+#### バグの修正
+
+- 読み取り専用トランザクションの状態管理動作を修正しました。([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- 証明書と秘密鍵のバージョンチェックとメッセージを修正しました。([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- 正しい認証設定のための Ledger 設定検証を修正しました。([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。([#262](https://github.com/scalar-labs/scalardl/pull/262))
+
+### Enterprise edition
+
+#### バグの修正
+
+- 正しい認証設定のための Auditor 設定検証を修正しました。
+- 重複した読み取りロックを修正しました。
+- [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874") を修正しました。
+
 ## v3.9.6
 
 **発売日:** 2025年6月20日

--- a/versioned_docs/version-3.10/releases/release-notes.mdx
+++ b/versioned_docs/version-3.10/releases/release-notes.mdx
@@ -9,6 +9,33 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDL 3.10.
 
+## v3.10.3
+
+**Release date:** October 8, 2025
+
+### Summary
+
+This release has several bug fixes and vulnerability fixes.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed the state management behavior for read-only transactions. ([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- Fixed certificate and secret key version check and messages. ([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- Fixed Ledger configuration validation for correct authentication settings. ([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874"). ([#262](https://github.com/scalar-labs/scalardl/pull/262))
+- Fixed [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146"). ([#286](https://github.com/scalar-labs/scalardl/pull/286))
+
+### Enterprise edition
+
+#### Bug fixes
+
+- Fixed Auditor configuration validation for correct authentication settings.
+- Fixed duplicated read lock.
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874").
+- Fixed [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146").
+
 ## v3.10.2
 
 **Release date:** June 20, 2025

--- a/versioned_docs/version-3.11/releases/release-notes.mdx
+++ b/versioned_docs/version-3.11/releases/release-notes.mdx
@@ -9,6 +9,38 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDL 3.11.
 
+## v3.11.1
+
+**Release date:** October 8, 2025
+
+### Summary
+
+This release has several improvements, bug fixes, and vulnerability fixes.
+
+### Community edition
+
+#### Improvements
+
+- Supported time-related data types in the generic function. ([#200](https://github.com/scalar-labs/scalardl/pull/200))
+
+#### Bug fixes
+
+- Fixed the state management behavior for read-only transactions. ([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- Fixed certificate and secret key version check and messages. ([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- Fixed Ledger configuration validation for correct authentication settings. ([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- Fixed `IS NULL` and `IS NOT NULL` conditions handling in table-oriented generic contracts. ([#238](https://github.com/scalar-labs/scalardl/pull/238))
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874"). ([#262](https://github.com/scalar-labs/scalardl/pull/262))
+- Fixed [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146"). ([#286](https://github.com/scalar-labs/scalardl/pull/286))
+
+### Enterprise edition
+
+#### Bug fixes
+
+- Fixed Auditor configuration validation for correct authentication settings.
+- Fixed duplicated read lock.
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874").
+- Fixed [CVE-2025-49146](https://github.com/advisories/GHSA-hq9p-pm7w-8p54 "CVE-2025-49146").
+
 ## v3.11.0
 
 **Release date:** June 18, 2025

--- a/versioned_docs/version-3.9/releases/release-notes.mdx
+++ b/versioned_docs/version-3.9/releases/release-notes.mdx
@@ -9,6 +9,31 @@ displayed_sidebar: docsEnglish
 
 This page includes a list of release notes for ScalarDL 3.9.
 
+## v3.9.7
+
+**Release date:** October 8, 2025
+
+### Summary
+
+This release has several bug fixes and vulnerability fixes.
+
+### Community edition
+
+#### Bug fixes
+
+- Fixed the state management behavior for read-only transactions. ([#181](https://github.com/scalar-labs/scalardl/pull/181))
+- Fixed certificate and secret key version check and messages. ([#202](https://github.com/scalar-labs/scalardl/pull/202))
+- Fixed Ledger configuration validation for correct authentication settings. ([#222](https://github.com/scalar-labs/scalardl/pull/222))
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874"). ([#262](https://github.com/scalar-labs/scalardl/pull/262))
+
+### Enterprise edition
+
+#### Bug fixes
+
+- Fixed Auditor configuration validation for correct authentication settings.
+- Fixed duplicated read lock.
+- Fixed [CVE-2025-22874](https://github.com/advisories/GHSA-6f52-wpx2-hvf2 "CVE-2025-22874").
+
 ## v3.9.6
 
 **Release date:** June 20, 2025


### PR DESCRIPTION
## Description

This PR:

- Adds patch version release notes for ScalarDL 3.12, 3.11, 3.10, and 3.9.
- Updates the patch versions listed in the Docusaurus configuration file. These patch versions determine which versions of Javadocs visitors are automatically routed to when they click the Javadoc links.

## Related issues and/or PRs

N/A

## Changes made

- Added patch version release notes for the following versions:
  - `3.12.1`
  - `3.11.1`
  - `3.10.3`
  - `3.9.7`
- Updated the latest patch versions in **docusaurus.config.js** for the `JavadocLink` component.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A