### PR TITLE
Add Scalar Manager usage guide and metrics reference to sidebar navigation

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -559,13 +559,28 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              id: 'scalar-kubernetes/alerts/Envoy',
-              label: 'Envoy Alerts',
+              id: 'scalar-manager/overview',
+              label: 'Scalar Manager Overview',
             },
             {
               type: 'doc',
-              id: 'scalar-kubernetes/alerts/Ledger',
-              label: 'Ledger Alerts',
+              id: 'scalar-manager/how-to-use-scalar-manager',
+              label: 'How to Use Scalar Manager',
+            },
+            {
+              type: 'doc',
+              id: 'scalar-manager/metrics-reference',
+              label: 'Scalar Manager Metrics Reference',
+            },
+            {
+              type: 'doc',
+              id: 'scalar-kubernetes/K8sMonitorGuide',
+              label: 'Kubernetes Monitoring Guide',
+            },
+            {
+              type: 'doc',
+              id: 'helm-charts/how-to-deploy-scalar-admin-for-kubernetes',
+              label: 'Deploy Scalar Admin for Kubernetes',
             },
             {
               type: 'category',
@@ -575,22 +590,17 @@ const sidebars = {
               items: [
                 {
                   type: 'doc',
-                  id: 'scalar-kubernetes/K8sMonitorGuide',
-                  label: 'Kubernetes Monitoring Guide',
+                  id: 'scalar-kubernetes/alerts/Envoy',
+                  label: 'Envoy Alerts',
                 },
                 {
                   type: 'doc',
-                  id: 'scalar-manager/overview',
-                  label: 'Scalar Manager Overview',
+                  id: 'scalar-kubernetes/alerts/Ledger',
+                  label: 'Ledger Alerts',
                 },
-                {
-                  type: 'doc',
-                  id: 'helm-charts/how-to-deploy-scalar-admin-for-kubernetes',
-                  label: 'Deploy Scalar Admin for Kubernetes',
-                },
-              ]
+              ],
             },
-          ]
+          ],
         },
         {
           type: 'category',
@@ -1218,14 +1228,29 @@ const sidebars = {
           },
           items: [
             {
-              type: 'doc',
-              id: 'scalar-kubernetes/alerts/Envoy',
-              label: 'Envoy アラート',
+              type: "doc",
+              id: "scalar-manager/overview",
+              label: "Scalar Manager の概要"
             },
             {
-              type: 'doc',
-              id: 'scalar-kubernetes/alerts/Ledger',
-              label: 'Ledger アラート',
+              type: "doc",
+              id: "scalar-manager/how-to-use-scalar-manager",
+              label: "Scalar Manager の使用方法"
+            },
+            {
+              type: "doc",
+              id: "scalar-manager/metrics-reference",
+              label: "Scalar Manager メトリクスリファレンス"
+            },
+            {
+              type: "doc",
+              id: "scalar-kubernetes/K8sMonitorGuide",
+              label: "Kubernetes モニタリングガイド"
+            },
+            {
+              type: "doc",
+              id: "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              label: "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
             },
             {
               type: 'category',
@@ -1235,22 +1260,17 @@ const sidebars = {
               items: [
                 {
                   type: 'doc',
-                  id: 'scalar-kubernetes/K8sMonitorGuide',
-                  label: 'Kubernetes モニタリングガイド',
+                  id: 'scalar-kubernetes/alerts/Envoy',
+                  label: 'Envoy アラート',
                 },
                 {
                   type: 'doc',
-                  id: 'scalar-manager/overview',
-                  label: 'Scalar Manager の概要',
+                  id: 'scalar-kubernetes/alerts/Ledger',
+                  label: 'Ledger アラート',
                 },
-                {
-                  type: 'doc',
-                  id: 'helm-charts/how-to-deploy-scalar-admin-for-kubernetes',
-                  label: 'Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ',
-                },
-              ]
-            }
-          ]
+              ],
+            },
+          ],
         },
         {
           type: 'category',

--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -509,13 +509,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy Alerts"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager Overview"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger Alerts"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "How to Use Scalar Manager"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager Metrics Reference"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes Monitoring Guide"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Deploy Scalar Admin for Kubernetes"
             },
             {
               "type": "category",
@@ -525,18 +540,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes Monitoring Guide"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy Alerts"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager Overview"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Deploy Scalar Admin for Kubernetes"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger Alerts"
                 }
               ]
             }
@@ -1137,13 +1147,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy アラート"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager の概要"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger アラート"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "Scalar Manager の使用方法"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager メトリクスリファレンス"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes モニタリングガイド"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
             },
             {
               "type": "category",
@@ -1153,18 +1178,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes モニタリングガイド"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy アラート"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager の概要"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger アラート"
                 }
               ]
             }

--- a/versioned_sidebars/version-3.11-sidebars.json
+++ b/versioned_sidebars/version-3.11-sidebars.json
@@ -514,13 +514,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy Alerts"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager Overview"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger Alerts"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "How to Use Scalar Manager"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager Metrics Reference"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes Monitoring Guide"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Deploy Scalar Admin for Kubernetes"
             },
             {
               "type": "category",
@@ -530,18 +545,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes Monitoring Guide"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy Alerts"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager Overview"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Deploy Scalar Admin for Kubernetes"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger Alerts"
                 }
               ]
             }
@@ -1147,13 +1157,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy アラート"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager の概要"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger アラート"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "Scalar Manager の使用方法"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager メトリクスリファレンス"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes モニタリングガイド"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
             },
             {
               "type": "category",
@@ -1163,18 +1188,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes モニタリングガイド"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy アラート"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager の概要"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger アラート"
                 }
               ]
             }

--- a/versioned_sidebars/version-3.12-sidebars.json
+++ b/versioned_sidebars/version-3.12-sidebars.json
@@ -529,13 +529,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy Alerts"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager Overview"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger Alerts"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "How to Use Scalar Manager"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager Metrics Reference"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes Monitoring Guide"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Deploy Scalar Admin for Kubernetes"
             },
             {
               "type": "category",
@@ -545,18 +560,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes Monitoring Guide"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy Alerts"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager Overview"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Deploy Scalar Admin for Kubernetes"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger Alerts"
                 }
               ]
             }
@@ -1177,13 +1187,28 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy アラート"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager の概要"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger アラート"
+              "id": "scalar-manager/how-to-use-scalar-manager",
+              "label": "Scalar Manager の使用方法"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-manager/metrics-reference",
+              "label": "Scalar Manager メトリクスリファレンス"
+            },
+            {
+              "type": "doc",
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes モニタリングガイド"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
             },
             {
               "type": "category",
@@ -1193,18 +1218,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes モニタリングガイド"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy アラート"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager の概要"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger アラート"
                 }
               ]
             }

--- a/versioned_sidebars/version-3.9-sidebars.json
+++ b/versioned_sidebars/version-3.9-sidebars.json
@@ -489,13 +489,18 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy Alerts"
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes Monitoring Guide"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger Alerts"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager Overview"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Deploy Scalar Admin for Kubernetes"
             },
             {
               "type": "category",
@@ -505,18 +510,13 @@
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes Monitoring Guide"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy Alerts"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager Overview"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Deploy Scalar Admin for Kubernetes"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger Alerts"
                 }
               ]
             }
@@ -1055,34 +1055,34 @@
           "items": [
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Envoy",
-              "label": "Envoy アラート"
+              "id": "scalar-kubernetes/K8sMonitorGuide",
+              "label": "Kubernetes Monitoring Guide"
             },
             {
               "type": "doc",
-              "id": "scalar-kubernetes/alerts/Ledger",
-              "label": "Ledger アラート"
+              "id": "scalar-manager/overview",
+              "label": "Scalar Manager Overview"
+            },
+            {
+              "type": "doc",
+              "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
+              "label": "Deploy Scalar Admin for Kubernetes"
             },
             {
               "type": "category",
               "key": "manage-monitor-reference-ja-jp-3.9",
-              "label": "詳細",
+              "label": "Reference",
               "collapsible": true,
               "items": [
                 {
                   "type": "doc",
-                  "id": "scalar-kubernetes/K8sMonitorGuide",
-                  "label": "Kubernetes モニタリングガイド"
+                  "id": "scalar-kubernetes/alerts/Envoy",
+                  "label": "Envoy Alerts"
                 },
                 {
                   "type": "doc",
-                  "id": "scalar-manager/overview",
-                  "label": "Scalar Manager の概要"
-                },
-                {
-                  "type": "doc",
-                  "id": "helm-charts/how-to-deploy-scalar-admin-for-kubernetes",
-                  "label": "Helm Chart を使用して Scalar Admin for Kubernetes をデプロイ"
+                  "id": "scalar-kubernetes/alerts/Ledger",
+                  "label": "Ledger Alerts"
                 }
               ]
             }


### PR DESCRIPTION
## Description

This PR adds docs for how to use Scalar Manager and a metrics reference for Scalar Manager to both the English and Japanese sidebar across all versions currently under Maintenance Support.

In addition, this PR moves the Scalar Manager docs from the second-level "Reference" category in the first-level "Monitor" category to the first-level "Monitor" category and moves the Envoy docs in the first-level "Monitor" category into the second-level "Reference" category in both the English and Japanese sidebar across all versions currently under Maintenance Support.

## Related issues and/or PRs

N/A

## Changes made

- Added docs for how to use Scalar Manager and a metrics reference for Scalar Manager in the English and Japanese sidebar navigation across supported versions.
- Moved the following in the English and Japanese sidebar navigation across supported versions:
  - Moved the Scalar Manager docs from the second-level "Reference" category in the first-level "Monitor" category to the first-level "Monitor" category.
  - Moved the Envoy docs in the first-level "Monitor" category into the second-level "Reference" category.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A