### PR TITLE
Add 3.13 blog post link to announcement banner and notification messages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -470,6 +470,7 @@ const config = {
         content:
           'Announcing the release of ScalarDL 3.13!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.',
           // '<b>Announcing the release of ScalarDL X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.</b>',
+          'Announcing the release of ScalarDL 3.13!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_self" href="XXX?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -468,9 +468,7 @@ const config = {
       announcementBar: {
         id: 'new_version',
         content:
-          'Announcing the release of ScalarDL 3.13!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.',
-          // '<b>Announcing the release of ScalarDL X.X!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a>.</b>',
-          'Announcing the release of ScalarDL 3.13!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_self" href="XXX?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
+          'Announcing the release of ScalarDL 3.13!🚀 For details on what\'s included in this new version, see the <a target="_self" href="/docs/latest/releases/release-notes?utm_source=docs-site&utm_medium=announcementbar">release notes</a> and <a target="_blank" href="https://medium.com/scalar-engineering/scalardl-3-13-has-been-released-a790a3b8a065?utm_source=docs-site&utm_medium=announcementbar">blog post</a>.',
         backgroundColor: '#2673BB',
         textColor: '#FFFFFF',
         isCloseable: false,

--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -1,6 +1,17 @@
 // This file contains the notifications data and a function to retrieve it.
 // The notifications are stored in an array of objects, each containing a message in multiple languages and URLs for those messages.
 const notificationsList = [
+  // {
+  //   message: {
+  //     en: 'XXX',
+  //     ja: 'XXX'
+  //   },
+  //   url: {
+  //     en: 'XXX?utm_source=docs-site&utm_medium=notifications',
+  //     ja: 'XXX?utm_source=docs-site&utm_medium=notifications'
+  //   },
+  //   unread: true
+  // },
   {
     message: {
       en: 'Find out about how to manage namespaces in ScalarDL 3.13',

--- a/src/data/notifications.js
+++ b/src/data/notifications.js
@@ -14,6 +14,17 @@ const notificationsList = [
   // },
   {
     message: {
+      en: 'Blog post: ScalarDL 3.13 has been released!',
+      ja: 'ブログ記事: ScalarDL 3.13 をリリースしました！'
+    },
+    url: {
+      en: 'https://medium.com/scalar-engineering/scalardl-3-13-has-been-released-a790a3b8a065?utm_source=docs-site&utm_medium=notifications',
+      ja: 'https://medium.com/scalar-engineering-ja/scalardl-3-13-%E3%81%8C%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%81%95%E3%82%8C%E3%81%BE%E3%81%97%E3%81%9F-8c6ea26c2bf2?utm_source=docs-site&utm_medium=notifications'
+    },
+    unread: true
+  },
+  {
+    message: {
       en: 'Find out about how to manage namespaces in ScalarDL 3.13',
       ja: 'ScalarDL 3.13 での名前空間管理について知る'
     },


### PR DESCRIPTION
## Description

This PR updates the announcement banner and notification message to highlight the release of ScalarDL 3.13.

## Related issues and/or PRs

N/A

## Changes made

* Added a link to the ScalarDL 3.13 release blog post in addition to the release notes in the announcement bar in `docusaurus.config.js`.
* Added a new notification about the ScalarDL 3.13 blog post, with messages and links in both English and Japanese, to `src/data/notifications.js`.
* Added a notification message template to `src/data/notifications.js`.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A