### PR TITLE
Add style for horizontal line below tab labels

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,11 @@
   --ifm-h1-font-size: 2.25rem;
 }
 
+/* Horizontal line separating tab labels from tab content */
+.tabs {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+}
+
 /* Make the sidebar navigation text smaller (default font size is 12pt). */
 .menu {
   font-size: 0.875rem;


### PR DESCRIPTION
## Description

This PR introduces a minor UI improvement to the documentation site by adding a horizontal line to visually separate tab labels from tab content.

> [!NOTE]
>
> **Screenshot showing the horizontal line under the tab labels:**
>
> <img width="947" height="365" alt="tabs-horizontal-line-docs-scalardl" src="https://github.com/user-attachments/assets/6c6115d9-2898-4b11-8b96-bb788bbffdfe" />

## Related issues and/or PRs

N/A

## Changes made

* Added a `border-bottom` to the `.tabs` class in `custom.css` to create a horizontal line separating tab labels from tab content.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A