### PR TITLE
Add `context7.json` to verify ownership in Context7 admin dashboard

### DIFF
--- a/static/context7.json
+++ b/static/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/scalardl_scalar-labs_llms-full_txt",
+  "public_key": "pk_diz7PUqkxvWebj3hJqJR5"
+}


### PR DESCRIPTION
## Description

This PR adds `context7.json` to verify that Scalar is the owner of the ScalarDL docs site in the [Context7](https://context7.com/) admin dashboard.

The contents of the `.json` file are from the Context7 account dashboard, as described in the [Claim your library](https://context7.com/docs/howto/claiming-libraries) documentation for Context7. This, apparently, should allow Context7 to automatically re-index the docs site's [`llms-full.txt`](https://scalardl.scalar-labs.com/llms-full.txt), which we've added in our Context7 account dashboard.

> [!NOTE]
>
> Context7 ([GitHub repository](https://github.com/upstash/context7)) is an MCP server and tool created by Upstash that automatically injects up-to-date, version-specific library documentation and code examples directly into your AI coding assistant's prompt

## Related issues and/or PRs

N/A

## Changes made

* Added `context7.json` to the `static` folder.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A