### PR TITLE
Revise DocVersionBanner with link to upgrade guide and translation improvements

### DIFF
--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -95,15 +95,15 @@
     "message": "バージョン: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "これはリリース前のバージョン{versionLabel}の{siteTitle}のドキュメントです。",
+    "message": "これはリリース前のバージョン{versionLabel}の {siteTitle} のドキュメントです。",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これはバージョン{versionLabel}の{siteTitle}のドキュメントで現在はメンテナンスされていません",
+    "message": "これはバージョン{versionLabel}の {siteTitle} のドキュメントで現在はメンテナンスされていません。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください",
+    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください。",
     "description": "The label used to tell the user to check the latest version"
   },
   "theme.docs.versions.latestVersionLinkLabel": {

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -95,12 +95,16 @@
     "message": "バージョン: {versionLabel}"
   },
   "theme.docs.versions.unreleasedVersionLabel": {
-    "message": "これはリリース前のバージョン{versionLabel}の {siteTitle} のドキュメントです。",
+    "message": "これはリリース前のバージョン{versionLabel}の ScalarDL のドキュメンテーションです。",
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これは {siteTitle} {versionLabel} のドキュメントです。このソフトウェアバージョンは現在アクティブにメンテナンスされていません。",
+    "message": "これは ScalarDL {versionLabel} のドキュメンテーションです。このソフトウェアバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.releaseSupportPolicyLinkLabel": {
+    "message": "リリースサポートポリシー",
+    "description": "The label used for the release support policy link label when the banner is 'unmaintained'"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
     "message": "ScalarDL {versionLabel} への{upgradeVersionLink}をご検討ください。",

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -99,7 +99,7 @@
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これは ScalarDL {versionLabel} のドキュメンテーションです。このソフトウェアバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
+    "message": "これは ScalarDL {versionLabel} のドキュメンテーションです。このバージョンはすでに Maintenance Support の対象外です。詳細は{releaseSupportPolicyLink}を参照してください。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.releaseSupportPolicyLinkLabel": {

--- a/i18n/versioned_docs/ja-jp/code.json
+++ b/i18n/versioned_docs/ja-jp/code.json
@@ -99,12 +99,16 @@
     "description": "The label used to tell the user that he's browsing an unreleased doc version"
   },
   "theme.docs.versions.unmaintainedVersionLabel": {
-    "message": "これはバージョン{versionLabel}の {siteTitle} のドキュメントで現在はメンテナンスされていません。",
+    "message": "これは {siteTitle} {versionLabel} のドキュメントです。このソフトウェアバージョンは現在アクティブにメンテナンスされていません。",
     "description": "The label used to tell the user that he's browsing an unmaintained doc version"
   },
   "theme.docs.versions.latestVersionSuggestionLabel": {
-    "message": "最新のドキュメントは{latestVersionLink} ({versionLabel}) を見てください。",
+    "message": "ScalarDL {versionLabel} への{upgradeVersionLink}をご検討ください。",
     "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.upgradeVersionLinkLabel": {
+    "message": "アップグレード",
+    "description": "The label used for the latest version suggestion link label when the banner is 'unmaintained'"
   },
   "theme.docs.versions.latestVersionLinkLabel": {
     "message": "最新バージョン",

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -1,0 +1,169 @@
+import React, {type ComponentType, type ReactNode} from 'react';
+import clsx from 'clsx';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import {
+  useActivePlugin,
+  useDocVersionSuggestions,
+  type GlobalVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {
+  useDocsPreferredVersion,
+  useDocsVersion,
+} from '@docusaurus/plugin-content-docs/client';
+import type {Props} from '@theme/DocVersionBanner';
+import type {
+  VersionBanner,
+  PropVersionMetadata,
+} from '@docusaurus/plugin-content-docs';
+
+type BannerLabelComponentProps = {
+  siteTitle: string;
+  versionMetadata: PropVersionMetadata;
+};
+
+function UnreleasedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unreleasedVersionLabel"
+      description="The label used to tell the user that he's browsing an unreleased doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+      }
+    </Translate>
+  );
+}
+
+function UnmaintainedVersionLabel({
+  siteTitle,
+  versionMetadata,
+}: BannerLabelComponentProps) {
+  return (
+    <Translate
+      id="theme.docs.versions.unmaintainedVersionLabel"
+      description="The label used to tell the user that he's browsing an unmaintained doc version"
+      values={{
+        siteTitle,
+        versionLabel: <b>{versionMetadata.label}</b>,
+      }}>
+      {
+        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+      }
+    </Translate>
+  );
+}
+
+const BannerLabelComponents: {
+  [banner in VersionBanner]: ComponentType<BannerLabelComponentProps>;
+} = {
+  unreleased: UnreleasedVersionLabel,
+  unmaintained: UnmaintainedVersionLabel,
+};
+
+function BannerLabel(props: BannerLabelComponentProps) {
+  const BannerLabelComponent =
+    BannerLabelComponents[props.versionMetadata.banner!];
+  return <BannerLabelComponent {...props} />;
+}
+
+function LatestVersionSuggestionLabel({
+  versionLabel,
+  to,
+  onClick,
+}: {
+  to: string;
+  onClick: () => void;
+  versionLabel: string;
+}) {
+  return (
+    <Translate
+      id="theme.docs.versions.latestVersionSuggestionLabel"
+      description="The label used to tell the user to check the latest version"
+      values={{
+        versionLabel,
+        latestVersionLink: (
+          <b>
+            <Link to={to} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.latestVersionLinkLabel"
+                description="The label used for the latest version suggestion link label">
+                latest version
+              </Translate>
+            </Link>
+          </b>
+        ),
+      }}>
+      {
+        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+      }
+    </Translate>
+  );
+}
+
+function DocVersionBannerEnabled({
+  className,
+  versionMetadata,
+}: Props & {
+  versionMetadata: PropVersionMetadata;
+}): ReactNode {
+  const {
+    siteConfig: {title: siteTitle},
+  } = useDocusaurusContext();
+  const {pluginId} = useActivePlugin({failfast: true})!;
+
+  const getVersionMainDoc = (version: GlobalVersion) =>
+    version.docs.find((doc) => doc.id === version.mainDocId)!;
+
+  const {savePreferredVersionName} = useDocsPreferredVersion(pluginId);
+
+  const {latestDocSuggestion, latestVersionSuggestion} =
+    useDocVersionSuggestions(pluginId);
+
+  // Try to link to same doc in latest version (not always possible), falling
+  // back to main doc of latest version
+  const latestVersionSuggestedDoc =
+    latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  return (
+    <div
+      className={clsx(
+        className,
+        ThemeClassNames.docs.docVersionBanner,
+        'alert alert--warning margin-bottom--md',
+      )}
+      role="alert">
+      <div>
+        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+      </div>
+      <div className="margin-top--md">
+        <LatestVersionSuggestionLabel
+          versionLabel={latestVersionSuggestion.label}
+          to={latestVersionSuggestedDoc.path}
+          onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function DocVersionBanner({className}: Props): ReactNode {
+  const versionMetadata = useDocsVersion();
+  if (versionMetadata.banner) {
+    return (
+      <DocVersionBannerEnabled
+        className={className}
+        versionMetadata={versionMetadata}
+      />
+    );
+  }
+  return null;
+}

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -23,11 +23,13 @@ import type {
 type BannerLabelComponentProps = {
   siteTitle: string;
   versionMetadata: PropVersionMetadata;
+  releaseSupportPolicyDocPath: string;
 };
 
 function UnreleasedVersionLabel({
   siteTitle,
   versionMetadata,
+  releaseSupportPolicyDocPath,
 }: BannerLabelComponentProps) {
   return (
     <Translate
@@ -38,7 +40,7 @@ function UnreleasedVersionLabel({
         versionLabel: <b>{versionMetadata.label}</b>,
       }}>
       {
-        'This is unreleased documentation for {siteTitle} {versionLabel} version.'
+        'This is unreleased documentation for ScalarDL {versionLabel}.'
       }
     </Translate>
   );
@@ -47,6 +49,7 @@ function UnreleasedVersionLabel({
 function UnmaintainedVersionLabel({
   siteTitle,
   versionMetadata,
+  releaseSupportPolicyDocPath,
 }: BannerLabelComponentProps) {
   return (
     <Translate
@@ -55,9 +58,20 @@ function UnmaintainedVersionLabel({
       values={{
         siteTitle,
         versionLabel: <b>{versionMetadata.label}</b>,
+        releaseSupportPolicyLink: (
+          <b>
+            <Link to={releaseSupportPolicyDocPath}>
+              <Translate
+                id="theme.docs.versions.releaseSupportPolicyLinkLabel"
+                description="The label used for the release support policy link label when the banner is 'unmaintained'">
+                Release Support Policy
+              </Translate>
+            </Link>
+          </b>
+        ),
       }}>
       {
-        'This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.'
+        'This is documentation for ScalarDL {versionLabel}, which is no longer under Maintenance Support. For details, see the {releaseSupportPolicyLink}.'
       }
     </Translate>
   );
@@ -119,7 +133,7 @@ function LatestVersionSuggestionLabel({
         ),
       }}>
       {
-        'Please consider {upgradeVersionLink} to {versionLabel}.'
+        'Please consider {upgradeVersionLink} to ScalarDL {versionLabel}.'
       }
     </Translate>
   );
@@ -150,16 +164,12 @@ function DocVersionBannerEnabled({
   const latestVersionSuggestedDoc =
     latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
 
-  // Find the upgrade doc in the current version
-  const getUpgradeDocPath = (): string => {
-    const upgradeDoc = activeVersion?.docs.find(
-      (doc) => doc.id.includes('HowToUpgradeScalarDL')
-    );
-    if (upgradeDoc) {
-      return upgradeDoc.path;
-    }
-    // Fallback to latest suggested doc if upgrade doc is not available
-    return latestVersionSuggestedDoc.path;
+  const getDocPathInCurrentVersion = (
+    docIdPart: string,
+    fallbackPath: string
+  ): string => {
+    const doc = activeVersion?.docs.find((item) => item.id.includes(docIdPart));
+    return doc?.path ?? fallbackPath;
   };
 
   return (
@@ -171,14 +181,24 @@ function DocVersionBannerEnabled({
       )}
       role="alert">
       <div>
-        <BannerLabel siteTitle={siteTitle} versionMetadata={versionMetadata} />
+        <BannerLabel
+          siteTitle="ScalarDL"
+          versionMetadata={versionMetadata}
+          releaseSupportPolicyDocPath={getDocPathInCurrentVersion(
+            'releases/release-support-policy',
+            latestVersionSuggestedDoc.path
+          )}
+        />
       </div>
       <div className="margin-top--md">
         <LatestVersionSuggestionLabel
           versionLabel={latestVersionSuggestion.label}
           to={latestVersionSuggestedDoc.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
-          upgradeDocPath={getUpgradeDocPath()}
+          upgradeDocPath={getDocPathInCurrentVersion(
+            'HowToUpgradeScalarDL',
+            latestVersionSuggestedDoc.path
+          )}
         />
       </div>
     </div>

--- a/src/theme/DocVersionBanner/index.tsx
+++ b/src/theme/DocVersionBanner/index.tsx
@@ -5,6 +5,7 @@ import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import {
   useActivePlugin,
+  useActiveVersion,
   useDocVersionSuggestions,
   type GlobalVersion,
 } from '@docusaurus/plugin-content-docs/client';
@@ -79,17 +80,21 @@ function LatestVersionSuggestionLabel({
   versionLabel,
   to,
   onClick,
+  upgradeDocPath,
 }: {
   to: string;
   onClick: () => void;
   versionLabel: string;
+  upgradeDocPath: string;
 }) {
   return (
     <Translate
       id="theme.docs.versions.latestVersionSuggestionLabel"
       description="The label used to tell the user to check the latest version"
       values={{
-        versionLabel,
+        versionLabel: (
+          <b>{versionLabel}</b>
+        ),
         latestVersionLink: (
           <b>
             <Link to={to} onClick={onClick}>
@@ -101,9 +106,20 @@ function LatestVersionSuggestionLabel({
             </Link>
           </b>
         ),
+        upgradeVersionLink: (
+          <b>
+            <Link to={upgradeDocPath} onClick={onClick}>
+              <Translate
+                id="theme.docs.versions.upgradeVersionLinkLabel"
+                description="The label used for the latest version suggestion link label when the banner is 'unmaintained'">
+                upgrading
+              </Translate>
+            </Link>
+          </b>
+        ),
       }}>
       {
-        'For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).'
+        'Please consider {upgradeVersionLink} to {versionLabel}.'
       }
     </Translate>
   );
@@ -119,6 +135,7 @@ function DocVersionBannerEnabled({
     siteConfig: {title: siteTitle},
   } = useDocusaurusContext();
   const {pluginId} = useActivePlugin({failfast: true})!;
+  const activeVersion = useActiveVersion(pluginId);
 
   const getVersionMainDoc = (version: GlobalVersion) =>
     version.docs.find((doc) => doc.id === version.mainDocId)!;
@@ -132,6 +149,18 @@ function DocVersionBannerEnabled({
   // back to main doc of latest version
   const latestVersionSuggestedDoc =
     latestDocSuggestion ?? getVersionMainDoc(latestVersionSuggestion);
+
+  // Find the upgrade doc in the current version
+  const getUpgradeDocPath = (): string => {
+    const upgradeDoc = activeVersion?.docs.find(
+      (doc) => doc.id.includes('HowToUpgradeScalarDL')
+    );
+    if (upgradeDoc) {
+      return upgradeDoc.path;
+    }
+    // Fallback to latest suggested doc if upgrade doc is not available
+    return latestVersionSuggestedDoc.path;
+  };
 
   return (
     <div
@@ -149,6 +178,7 @@ function DocVersionBannerEnabled({
           versionLabel={latestVersionSuggestion.label}
           to={latestVersionSuggestedDoc.path}
           onClick={() => savePreferredVersionName(latestVersionSuggestion.name)}
+          upgradeDocPath={getUpgradeDocPath()}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This PR refactors the banner for unmaintained versions of docs to guide users to the doc for how to upgrade their version of ScalarDL. Previously, the banner directed users to the latest version of ScalarDL docs (this is the default behavior in Docusaurus), but doing so doesn't recommend or guide users on how to upgrade ScalarDL.

You can see how the banner looks in the following staging environment: https://verdant-twilight-dl-unmaintained.netlify.app/docs/3.10/

## Related issues and/or PRs

A similar PR has been made for the ScalarDB docs site:

- https://github.com/scalar-labs/docs-scalardb/pull/2279

## Changes made

**Component refactor and UX enhancements**

* Refactored `DocVersionBanner` into a modular React component, introducing distinct subcomponents for unreleased and unmaintained banners, and for the version suggestion label. (`src/theme/DocVersionBanner/index.tsx`)
* The banner now explicitly suggests upgrading to the latest version and, when possible, links directly to the upgrade guide (`HowToUpgradeScalarDL`). If the upgrade guide isn't found, it falls back to the main doc of the latest version. (`src/theme/DocVersionBanner/index.tsx`)
* Improved accessibility and visual clarity by restructuring the banner layout and using semantic HTML and CSS classes. (`src/theme/DocVersionBanner/index.tsx`)

**Japanese language improvements**
* Updated Japanese translation strings for unmaintained version labels and latest version suggestions to provide clearer messaging and actionable upgrade prompts. Added a new label for the upgrade link. (`i18n/versioned_docs/ja-jp/code.json`)

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A