### PR TITLE
Mark ScalarDL 3.10 as out of Maintenance Support; update patch versions 

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -94,7 +94,7 @@ const config = {
               "3.10": {
                 label: '3.10',
                 path: '3.10',
-                banner: 'none',
+                banner: 'unmaintained',
                 className: '3.10.5',
               },
             },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,19 +83,19 @@ const config = {
                 label: '3.12',
                 path: '3.12', // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 banner: 'none',
-                className: '3.12.2',
+                className: '3.12.3',
               },
               "3.11": { // When a new version is released and this is no longer the current version, change this to the version number and then delete this comment.
                 label: '3.11',
                 path: '3.11',
                 banner: 'none',
-                className: '3.11.2',
+                className: '3.11.3',
               },
               "3.10": {
                 label: '3.10',
                 path: '3.10',
                 banner: 'none',
-                className: '3.10.4',
+                className: '3.10.5',
               },
             },
           },


### PR DESCRIPTION
## Description

This PR marks ScalarDL 3.10 as no longer under Maintenance Support, which ends on June 18, 2026 (according to the [Release Support Policy](https://scalardl.scalar-labs.com/docs/latest/releases/release-support-policy)), and updates the patch versions for versions 3.12, 3.11, and 3.10 versions.

## Related issues and/or PRs

N/A

## Changes made

* Set `banner` in **docusaurus.config.js**  for 3.10 docs to 'unmaintained' to indicate that the version is no longer actively maintained.
* Updated the patch version for the following versions: 3.12 (from `'3.12.2'` to `'3.12.3'`), 3.11 (from `'3.11.2'` to `'3.11.3'`), and 3.10 (from `'3.10.4'` to `'3.10.5'`).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A