### PR TITLE
Fix how `llms-full.txt` is fetched from copy button on Japanese version of docs site

### DIFF
--- a/src/components/CopyContents/index.tsx
+++ b/src/components/CopyContents/index.tsx
@@ -176,9 +176,21 @@ interface CopyContentsProps {
 export default function CopyContents({ showLlmsButtons = false, hideMarkdownButton = false }: CopyContentsProps): JSX.Element {
   const [copyStatus, setCopyStatus] = useState<Record<string, CopyStatus>>({});
   const location = useLocation();
-  const { siteConfig } = useDocusaurusContext();
+  const { siteConfig, i18n } = useDocusaurusContext();
+  const currentLocale = i18n?.currentLocale ?? '';
 
   const currentPageUrl = `${siteConfig.url}${location.pathname}`;
+
+  const getNonLocalizedBaseUrl = useCallback((): string => {
+    const baseUrl = siteConfig.baseUrl.endsWith('/') ? siteConfig.baseUrl : `${siteConfig.baseUrl}/`;
+    if (!currentLocale) return baseUrl;
+    // Docusaurus localizes baseUrl (for example, '/ja-jp/'). Strip the locale segment
+    // so llms-full.txt can be fetched from the shared root location.
+    const localeSuffix = `/${currentLocale}/`;
+    return baseUrl.endsWith(localeSuffix)
+      ? baseUrl.replace(new RegExp(`${localeSuffix}$`), '/')
+      : baseUrl;
+  }, [siteConfig.baseUrl, currentLocale]);
 
   const trackEvent = useCallback((action: string) => {
     if (typeof gtag !== 'undefined') {
@@ -230,7 +242,7 @@ export default function CopyContents({ showLlmsButtons = false, hideMarkdownButt
   const handleCopyLlmsFullTxt = async () => {
     trackEvent('copy_llms_full_txt');
     try {
-      const text = await fetchTextFile(`${siteConfig.baseUrl}llms-full.txt`);
+      const text = await fetchTextFile(`${getNonLocalizedBaseUrl()}llms-full.txt`);
       await copyToClipboard(text);
       setCopied('llmsFull', true);
     } catch {


### PR DESCRIPTION
## Description

This PR fixes the **llms-full.txt をコピー** button on the Japanese version of the docs site, which encounters a failure when the button is pressed. To fix this issue, this PR updates the `CopyContents` component to better handle localization when fetching the `llms-full.txt` file. The main improvement is ensuring that the file is always fetched from the non-localized base URL, regardless of the current language locale. This prevents errors when the site is viewed in different languages.

## Related issues and/or PRs

Similar fix made on the ScalarDB docs site:

- https://github.com/scalar-labs/docs-scalardb/pull/2315

## Changes made

* Added logic to extract the current locale from Docusaurus context and compute a non-localized `baseUrl` by stripping out the locale segment, ensuring shared resources like `llms-full.txt` are always fetched from the correct root location.
* Updated the fetch call for `llms-full.txt` to use the new non-localized base URL, preventing 404 errors when the site is accessed in a localized context.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A