### PR TITLE
Mark ScalarDL 3.10 as out of Maintenance Support

### DIFF
--- a/docs/releases/release-support-policy.mdx
+++ b/docs/releases/release-support-policy.mdx
@@ -51,7 +51,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/current/releases/release-support-policy.mdx
@@ -55,7 +55,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.10/releases/release-support-policy.mdx
@@ -34,7 +34,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.11/releases/release-support-policy.mdx
@@ -41,7 +41,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>

--- a/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.12/releases/release-support-policy.mdx
+++ b/i18n/versioned_docs/ja-jp/docusaurus-plugin-content-docs/version-3.12/releases/release-support-policy.mdx
@@ -48,7 +48,7 @@ import TranslationBanner from '/src/components/_translation-ja-jp.mdx';
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/ja-jp/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://www.scalar-labs.com/ja/contact">お問い合わせ</a></td>
     </tr>

--- a/versioned_docs/version-3.10/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.10/releases/release-support-policy.mdx
@@ -30,7 +30,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>

--- a/versioned_docs/version-3.11/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.11/releases/release-support-policy.mdx
@@ -37,7 +37,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>

--- a/versioned_docs/version-3.12/releases/release-support-policy.mdx
+++ b/versioned_docs/version-3.12/releases/release-support-policy.mdx
@@ -44,7 +44,7 @@ This page describes Scalar's support policy for major and minor version releases
     <tr>
       <td><a href="https://scalardl.scalar-labs.com/docs/3.10/releases/release-notes#v3100">3.10</a></td>
       <td>2024-12-05</td>
-      <td>2026-06-18</td>
+      <td class="version-out-of-maintenance-support">2026-06-18</td>
       <td>2026-12-15</td>
       <td><a href="https://scalar-labs.com/en/contact">Contact us</a></td>
     </tr>


### PR DESCRIPTION
## Description

This PR marks ScalarDL 3.10 as out of Maintenance Support (ended on June 18, 2026).

## Related issues and/or PRs

We should have been done in the following PR:

- https://github.com/scalar-labs/docs-scalardl/pull/1376

## Changes made

- In each version of the Release Support Policy docs, added the `version-out-of-maintenance-support` style to the `Maintenance Support Ends` cell for 3.10.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A