### PR TITLE
Refactor tag handling in DocItemLayout and update DocVersionBadge

### DIFF
--- a/src/theme/DocItem/Layout/index.tsx
+++ b/src/theme/DocItem/Layout/index.tsx
@@ -13,7 +13,6 @@ import DocBreadcrumbs from '@theme/DocBreadcrumbs';
 import ContentVisibility from '@theme/ContentVisibility';
 import CopyContents from '@site/src/components/CopyContents';
 import ChatWithPage from '@site/src/components/ChatWithPage';
-
 import styles from './styles.module.css';
 
 const BADGE_PATTERN = /\[[A-Z]+\]$/;
@@ -75,6 +74,7 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
   const isHomePage = metadata.slug === '/';
   const isLatestVersion = versionMetadata.isLast;
   const isNew = frontMatter['new'] || (sidebar != null && sidebarItemHasBadge(sidebar.items, metadata.permalink));
+  const tags = metadata.tags ?? [];
 
   return (
     <>
@@ -92,7 +92,7 @@ const DocItemLayout: React.FC<DocItemLayoutProps> = ({ children }) => {
                 <CopyContents showLlmsButtons={isHomePage && isLatestVersion} hideMarkdownButton={isHomePage} />
               </div>
             </div>
-            <DocVersionBadge />
+            <DocVersionBadge tags={tags} />
             {isNew && <span className="sr-only">New</span>}
             {docTOC.mobile}
             <DocItemContent>{children}</DocItemContent>

--- a/src/theme/DocVersionBadge/index.tsx
+++ b/src/theme/DocVersionBadge/index.tsx
@@ -9,25 +9,25 @@ import React from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsVersion, useDoc} from '@docusaurus/plugin-content-docs/client';
+import {useDocsVersion} from '@docusaurus/plugin-content-docs/client';
 import type {Props} from '@theme/DocVersionBadge';
 import TagsListInline from '@theme/TagsListInline';
-// Import the original mapper
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'; // Import the FontAwesomeIcon component.
-import { library } from '@fortawesome/fontawesome-svg-core'; // Import the library component.
-import { fab } from '@fortawesome/free-brands-svg-icons'; // Import all brands icons.
-import { far, faCircleQuestion } from '@fortawesome/free-regular-svg-icons'; // Import all solid icons.
-import { fas } from '@fortawesome/free-solid-svg-icons'; // Import all solid icons.
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { fab } from '@fortawesome/free-brands-svg-icons';
+import { far, faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
+import { fas } from '@fortawesome/free-solid-svg-icons';
 
-library.add(fab, fas, far, faCircleQuestion); // Add all icons to the library so you can use them without importing them individually.
+library.add(fab, fas, far, faCircleQuestion);
+
+type DocVersionBadgeProps = Props & {
+  tags?: readonly {label: string; permalink: string}[];
+};
 
 export default function DocVersionBadge({
   className,
-}: Props): JSX.Element | null {
-
-  const {metadata} = useDoc();
-  const {tags} = metadata;
-
+  tags = [],
+}: DocVersionBadgeProps): JSX.Element | null {
   const versionMetadata = useDocsVersion();
 
   // Normalize and deduplicate Enterprise tags.
@@ -60,16 +60,21 @@ export default function DocVersionBadge({
           values={{versionLabel: versionMetadata.label}}>
           {'Version: {versionLabel}'}
         </Translate>
-        <div
-          className={clsx(
-            'row margin-top--sm',
-            ThemeClassNames.docs.docFooterTagsRow,
-          )}>
-          <div className="col">
-            <TagsListInline tags={normalizedTags} />
-            <a href="https://scalar-labs.com/pricing/" target="_blank" className="fa-solid fa-circle-question tooltip"><FontAwesomeIcon icon={faCircleQuestion} size="lg" /><span className="tooltiptext">Features and pricing</span></a>
+        {normalizedTags.length > 0 && (
+          <div
+            className={clsx(
+              'row margin-top--sm',
+              ThemeClassNames.docs.docFooterTagsRow,
+            )}>
+            <div className="col">
+              <TagsListInline tags={normalizedTags} />
+              <a href="https://scalar-labs.com/pricing/" target="_blank" className="fa-solid fa-circle-question tooltip">
+                <FontAwesomeIcon icon={faCircleQuestion} size="lg" />
+                <span className="tooltiptext">Features and pricing</span>
+              </a>
+            </div>
           </div>
-        </div>
+        )}
       </span>
     );
   }


### PR DESCRIPTION
## Description

This pull request updates how tags are passed and displayed in the documentation version badge component, ensuring that tags from the document metadata are properly shown alongside the version badge. It also refactors the `DocVersionBadge` component to accept tags as a prop instead of accessing them directly from context, improving component reusability and clarity.

> [!NOTE]
>
> This change is needed because the customization we had previously made (in https://github.com/scalar-labs/docs-scalardl/pull/685) conflicts with the ability to use the [generated index page function in Docusaurus](https://docusaurus.io/docs/sidebar/items#generated-index-page).

## Related issues and/or PRs

Similar changes made in the other docs site repositories:

- https://github.com/scalar-labs/docs-scalardb/pull/2341
- https://github.com/scalar-labs/docs-archive/pull/12

## Changes made

* Retrieves tags from `metadata` and passes them as a prop to `DocVersionBadge`, instead of relying on internal context.
* Updates the `DocVersionBadge` component to accept a `tags` prop, defaulting to an empty array, and renders the tags (and the pricing link) only if tags are present.
* Removes unused imports and internal fetching of tags from metadata, simplifying the component interface.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A