### PR TITLE
Add redirects for archived versions; update label for archived docs in version dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,13 +168,20 @@ const config = {
           },
         ],
         createRedirects(existingPath) {
+          const redirects = [];
           if (existingPath.includes('/ja-jp/docs')) {
             // Redirect from /docs/ja-jp/X to /ja-jp/docs/X.
-            return [
-              existingPath.replace('/ja-jp/docs', '/docs/ja-jp'),
-            ];
+            redirects.push(existingPath.replace('/ja-jp/docs', '/docs/ja-jp'));
           }
-          return undefined; // Return a falsy value: no redirect created
+          if (existingPath.startsWith('/docs/latest/')) {
+            // Redirect from /docs/<OLD_VERSION>/X to /docs/latest/X for versions
+            // that are no longer built (3.4 through 3.9).
+            const retiredVersions = ['3.9', '3.8', '3.7', '3.6', '3.5', '3.4'];
+            for (const version of retiredVersions) {
+              redirects.push(existingPath.replace('/docs/latest/', `/docs/${version}/`));
+            }
+          }
+          return redirects.length ? redirects : undefined;
         },
       },
     ],

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -63,7 +63,7 @@ export default function DocsVersionDropdownNavbarItem({
     {
       label: translate({
         id: 'navbar.unsupportedVersions',
-        message: 'Unsupported Versions',
+        message: 'Archived versions',
       }),
       to: 'https://docs-archive.scalar-labs.com/?products=scalardl',
     },


### PR DESCRIPTION
## Description

This PR introduces improvements to documentation redirects. The main changes include enhancing the redirect logic to handle archived documentation versions (which have been moved to the [docs-archive site](https://docs-archive.scalar-labs.com)) so that users and LLMs/bots don't land on the default "Page not found" page for pages that no longer exist.

Another minor change in this PR is updating the wording for the link to the archived docs from "Unsupported Versions" to "Archived versions".

## Related issues and/or PRs

Similar changes made in the ScalarDL docs site repository:

- https://github.com/scalar-labs/docs-scalardb/pull/2388

## Changes made

**Redirect logic improvements**

* Improved the `createRedirects` function in `docusaurus.config.js` to generate redirects for retired documentation versions (3.4 through 3.9) by mapping `/docs/latest/` URLs to their corresponding archived version paths.

**Navigation terminology update**

* Changed the navigation dropdown label from "Unsupported Versions" to "Archived Versions" in `DocsVersionDropdownNavbarItem.js` to improve clarity for users.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A