### PR TITLE
Fix MDX component inlining for relative import paths used for "Copy page as Markdown" button

### DIFF
--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -15,12 +15,12 @@
  * after the Webpack/Rspack build so the `outDir` already exists).
  *
  * MDX component inlining: When a doc imports a local `.mdx` component (e.g.
- * `import Foo from '/src/components/en-us/_foo.mdx'`) and uses it as a JSX
- * self-closing tag (e.g. `<Foo bar="baz" />`), this plugin reads the component
- * file, substitutes `{props.bar}` with `"baz"`, and replaces the JSX tag with
- * the inlined content. This ensures the copied Markdown is fully readable
- * outside Docusaurus (e.g., admonitions from `_warning-*.mdx` are inlined as
- * `:::warning` blocks). Import lines for inlined `.mdx` components are removed.
+ * `import Foo from './components/_foo.mdx'` or `import Foo from '/src/components/en-us/_foo.mdx'`)
+ * and uses it as a JSX self-closing tag (e.g. `<Foo bar="baz" />`), this plugin
+ * reads the component file, substitutes `{props.bar}` with `"baz"`, and replaces
+ * the JSX tag with the inlined content. Nesting is handled recursively, so a
+ * component that itself imports other `.mdx` partials is fully resolved.
+ * Import lines for inlined `.mdx` components are removed from the output.
  */
 
 'use strict';
@@ -42,20 +42,22 @@ function stripFrontMatter(content) {
 }
 
 /**
- * Resolve a path (possibly `@site/`-prefixed or root-relative `/src/...`) to an
- * absolute filesystem path.
- * @param {string} importPath  e.g. "/src/components/en-us/_foo.mdx"
+ * Resolve a path (possibly `@site/`-prefixed, root-relative `/src/...`, or
+ * doc-relative `./components/...`) to an absolute filesystem path.
+ * @param {string} importPath  e.g. "/src/components/en-us/_foo.mdx" or "./components/_foo.mdx"
  * @param {string} siteDir     absolute path to the Docusaurus site root
+ * @param {string} docDir      absolute path to the importing doc's directory
  * @returns {string}
  */
-function resolveSource(importPath, siteDir) {
+function resolveSource(importPath, siteDir, docDir = siteDir) {
   if (importPath.startsWith('@site/')) {
     return path.join(siteDir, importPath.slice('@site/'.length));
   }
   if (path.isAbsolute(importPath)) {
     return path.join(siteDir, importPath);
   }
-  return path.join(siteDir, importPath);
+  // Relative paths (e.g. `./components/_foo.mdx`) are relative to the importing doc.
+  return path.resolve(docDir, importPath);
 }
 
 /**
@@ -185,9 +187,10 @@ function absolutizeMarkdownLinks(markdown, permalink, siteUrl) {
  * @param {string} source
  * @param {string} siteDir
  * @param {Map<string, string>} cache  Shared across all docs; maps absolute path → processed body.
+ * @param {string} docDir  Absolute path to the importing doc's directory.
  * @returns {Promise<string>}
  */
-async function inlineMdxComponents(source, siteDir, cache) {
+async function inlineMdxComponents(source, siteDir, cache, docDir) {
   // 1. Collect all `import X from '.../file.mdx'` statements.
   //    Only local `.mdx` files are inlinable; theme/npm imports are skipped.
   const importLineRegex =
@@ -198,7 +201,7 @@ async function inlineMdxComponents(source, siteDir, cache) {
   let m;
   while ((m = importLineRegex.exec(source)) !== null) {
     const [, name, importPath] = m;
-    mdxImports.set(name, resolveSource(importPath, siteDir));
+    mdxImports.set(name, resolveSource(importPath, siteDir, docDir));
   }
 
   if (mdxImports.size === 0) return source;
@@ -214,12 +217,16 @@ async function inlineMdxComponents(source, siteDir, cache) {
       } else {
         body = await fs.promises.readFile(filePath, 'utf8');
         body = stripFrontMatter(body);
-        // Strip nested import lines (for example `import Tabs from '@theme/Tabs'`)
-        // so the inlined content doesn't contain unresolvable MDX imports.
+        // Strip non-.mdx imports (for example `import Tabs from '@theme/Tabs'`); local
+        // .mdx imports are left for the recursive inlineMdxComponents call below.
         body = body.replace(
-          /^import\s+[A-Za-z0-9_{}, *]+\s+from\s+['"][^'"]+['"]\s*;?\s*\n?/gm,
+          /^import\s+[A-Za-z0-9_{}, *]+\s+from\s+['"][^'"]*(?<!\.mdx)['"]\s*;?\s*\n?/gm,
           '',
         );
+        // Seed cache before recursing so circular imports don't loop.
+        cache.set(filePath, body.trim());
+        // Recursively inline any nested local .mdx components.
+        body = await inlineMdxComponents(body, siteDir, cache, path.dirname(filePath));
         body = body.trim();
         cache.set(filePath, body);
       }
@@ -349,7 +356,7 @@ module.exports = function copyPageSourcePlugin(context) {
           .readFile(sourcePath, 'utf8')
           .then(async (raw) => {
             let content = stripFrontMatter(raw);
-            content = await inlineMdxComponents(content, context.siteDir, componentCache);
+            content = await inlineMdxComponents(content, context.siteDir, componentCache, path.dirname(sourcePath));
             if (siteUrl) {
               content = absolutizeMarkdownLinks(content, permalink, siteUrl);
             }

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -228,6 +228,7 @@ async function inlineMdxComponents(source, siteDir, cache, docDir) {
         // Recursively inline any nested local .mdx components.
         body = await inlineMdxComponents(body, siteDir, cache, path.dirname(filePath));
         body = body.trim();
+        // Update cache with fully resolved body.
         cache.set(filePath, body);
       }
       componentBodies.set(name, body);
@@ -346,30 +347,27 @@ module.exports = function copyPageSourcePlugin(context) {
 
       const localeDir = path.basename(outDir);
 
-      const writes = docEntries.map(({ permalink, sourcePath }) => {
+      // Sequential so the shared componentCache is never read mid-update.
+      for (const { permalink, sourcePath } of docEntries) {
         const permalinkPath = permalink.replace(/^\//, '');
         const outputPath = permalinkPath.startsWith(`${localeDir}/`)
           ? permalinkPath.slice(localeDir.length + 1)
           : permalinkPath;
         const destPath = path.join(outDir, outputPath, 'source.md');
-        return fs.promises
-          .readFile(sourcePath, 'utf8')
-          .then(async (raw) => {
-            let content = stripFrontMatter(raw);
-            content = await inlineMdxComponents(content, context.siteDir, componentCache, path.dirname(sourcePath));
-            if (siteUrl) {
-              content = absolutizeMarkdownLinks(content, permalink, siteUrl);
-            }
-            content = content.trimStart();
-            await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-            await fs.promises.writeFile(destPath, content, 'utf8');
-          })
-          .catch((err) => {
-            console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
-          });
-      });
-
-      await Promise.all(writes);
+        try {
+          const raw = await fs.promises.readFile(sourcePath, 'utf8');
+          let content = stripFrontMatter(raw);
+          content = await inlineMdxComponents(content, context.siteDir, componentCache, path.dirname(sourcePath));
+          if (siteUrl) {
+            content = absolutizeMarkdownLinks(content, permalink, siteUrl);
+          }
+          content = content.trimStart();
+          await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+          await fs.promises.writeFile(destPath, content, 'utf8');
+        } catch (err) {
+          console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
+        }
+      }
       console.log(`[copy-page-source] Wrote source.md for ${docEntries.length} pages to ${outDir}.`);
     },
   };


### PR DESCRIPTION
## Description

This PR fixes the MDX component inlining logic in the `copy-page-source` plugin (used in the "Copy page as Markdown" button) to support recursive inlining of nested local `.mdx` components and to correctly resolve relative import paths. It also improves handling of import statements to ensure only non-MDX imports are stripped, and prevents infinite loops due to circular imports.

## Related issues and/or PRs

A similar PR was created for the ScalarDB docs site:

- https://github.com/scalar-labs/docs-scalardb/pull/2436

## Changes made

**Improvements to MDX component inlining**

* The plugin now recursively inlines nested local `.mdx` components, so if an inlined MDX file itself imports other partials, those are also resolved and inlined.
* The `inlineMdxComponents` function now takes an additional `docDir` parameter to properly resolve relative import paths based on the importing document's directory.
* The cache is seeded before recursing, preventing infinite loops in case of circular imports.

**Import statement handling**

* The logic for stripping import statements now only removes non-`.mdx` imports, ensuring that nested `.mdx` imports are handled recursively and not prematurely removed.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A