### PR TITLE
Serve raw Markdown at `<URL>.md` and advertise it to AI agents

### DIFF
--- a/src/components/CopyContents/index.tsx
+++ b/src/components/CopyContents/index.tsx
@@ -216,7 +216,7 @@ export default function CopyContents({ showLlmsButtons = false, hideMarkdownButt
       let markdown: string;
       try {
         const pathname = location.pathname.replace(/\/$/, '');
-        markdown = await fetchTextFile(`${pathname}/source.md`);
+        markdown = await fetchTextFile(`${pathname}.md`);
       } catch {
         markdown = getPageMarkdown();
         if (!markdown) throw new Error('No content found');

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -385,6 +385,8 @@ module.exports = function copyPageSourcePlugin(context) {
             content = absolutizeMarkdownLinks(content, permalink, siteUrl);
           }
           content = content.trimStart();
+          // Ensure headings are preceded by a blank line (MDX doesn't require it, Markdown does).
+          content = content.replace(/([^\n])\n(#{1,6} )/g, '$1\n\n$2');
           await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
           await fs.promises.writeFile(destPath, content, 'utf8');
 

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -14,13 +14,13 @@
  * during `allContentLoaded` and then write the files in `postBuild` (which runs
  * after the Webpack/Rspack build so the `outDir` already exists).
  *
- * MDX component inlining: When a doc imports a local `.mdx` component (e.g.
- * `import Foo from '/src/components/en-us/_foo.mdx'`) and uses it as a JSX
- * self-closing tag (e.g., `<Foo bar="baz" />`), this plugin reads the component
- * file, substitutes `{props.bar}` with `"baz"`, and replaces the JSX tag with
- * the inlined content. This ensures the copied Markdown is fully readable
- * outside Docusaurus (e.g., admonitions from `_warning-*.mdx` are inlined as
- * `:::warning` blocks). Import lines for inlined `.mdx` components are removed.
+ * MDX component inlining: When a doc imports a local `.mdx` component (e.g.,
+ * `import Foo from './components/_foo.mdx'`) and uses it as a JSX self-closing
+ * tag (e.g., `<Foo bar="baz" />`), this plugin reads the component file,
+ * substitutes `{props.bar}` with `"baz"`, and replaces the JSX tag with the
+ * inlined content. Nesting is handled recursively, so a component that itself
+ * imports other `.mdx` partials is fully resolved. Import lines for inlined
+ * `.mdx` components are removed from the output.
  */
 
 'use strict';
@@ -42,20 +42,22 @@ function stripFrontMatter(content) {
 }
 
 /**
- * Resolve a path (possibly `@site/`-prefixed or root-relative `/src/...`) to an
- * absolute filesystem path.
- * @param {string} importPath  e.g., "/src/components/en-us/_foo.mdx"
+ * Resolve a path (possibly `@site/`-prefixed, root-relative `/src/...`, or
+ * doc-relative `./components/...`) to an absolute filesystem path.
+ * @param {string} importPath  e.g., "./components/_foo.mdx"
  * @param {string} siteDir     absolute path to the Docusaurus site root
+ * @param {string} docDir      absolute path to the importing doc's directory
  * @returns {string}
  */
-function resolveSource(importPath, siteDir) {
+function resolveSource(importPath, siteDir, docDir = siteDir) {
   if (importPath.startsWith('@site/')) {
     return path.join(siteDir, importPath.slice('@site/'.length));
   }
   if (path.isAbsolute(importPath)) {
     return path.join(siteDir, importPath);
   }
-  return path.join(siteDir, importPath);
+  // Relative paths (e.g. `./components/_foo.mdx`) are relative to the importing doc.
+  return path.resolve(docDir, importPath);
 }
 
 /**
@@ -203,9 +205,10 @@ function absolutizeMarkdownLinks(markdown, permalink, siteUrl) {
  * @param {string} source
  * @param {string} siteDir
  * @param {Map<string, string>} cache  Shared across all docs; maps absolute path → processed body.
+ * @param {string} docDir  Absolute path to the importing doc's directory.
  * @returns {Promise<string>}
  */
-async function inlineMdxComponents(source, siteDir, cache) {
+async function inlineMdxComponents(source, siteDir, cache, docDir) {
   // 1. Collect all `import X from '.../file.mdx'` statements.
   //    Only local `.mdx` files are inlinable; theme/npm imports are skipped.
   const importLineRegex =
@@ -216,7 +219,7 @@ async function inlineMdxComponents(source, siteDir, cache) {
   let m;
   while ((m = importLineRegex.exec(source)) !== null) {
     const [, name, importPath] = m;
-    mdxImports.set(name, resolveSource(importPath, siteDir));
+    mdxImports.set(name, resolveSource(importPath, siteDir, docDir));
   }
 
   if (mdxImports.size === 0) return source;
@@ -232,13 +235,18 @@ async function inlineMdxComponents(source, siteDir, cache) {
       } else {
         body = await fs.promises.readFile(filePath, 'utf8');
         body = stripFrontMatter(body);
-        // Strip nested import lines (e.g., `import Tabs from '@theme/Tabs'`)
-        // so the inlined content doesn't contain unresolvable MDX imports.
+        // Strip non-.mdx imports (e.g., `import Tabs from '@theme/Tabs'`); local
+        // .mdx imports are left for the recursive inlineMdxComponents call below.
         body = body.replace(
-          /^import\s+[A-Za-z0-9_{}, *]+\s+from\s+['"][^'"]+['"]\s*;?\s*\n?/gm,
+          /^import\s+[A-Za-z0-9_{}, *]+\s+from\s+['"][^'"]*(?<!\.mdx)['"]\s*;?\s*\n?/gm,
           '',
         );
+        // Seed cache before recursing so circular imports don't loop.
+        cache.set(filePath, body.trim());
+        // Recursively inline any nested local .mdx components.
+        body = await inlineMdxComponents(body, siteDir, cache, path.dirname(filePath));
         body = body.trim();
+        // Update cache with fully-resolved body.
         cache.set(filePath, body);
       }
       componentBodies.set(name, body);
@@ -365,45 +373,42 @@ module.exports = function copyPageSourcePlugin(context) {
           : permalinkPath;
       };
 
-      const writes = docEntries.map(({ permalink, sourcePath }) => {
+      // Sequential so the shared componentCache is never read mid-update.
+      for (const { permalink, sourcePath } of docEntries) {
         const outputPath = toOutputPath(permalink);
         const destPath = path.join(outDir, outputPath, 'source.md');
-        return fs.promises
-          .readFile(sourcePath, 'utf8')
-          .then(async (raw) => {
-            let content = stripFrontMatter(raw);
-            content = await inlineMdxComponents(content, context.siteDir, componentCache);
-            if (siteUrl) {
-              content = absolutizeMarkdownLinks(content, permalink, siteUrl);
-            }
-            content = content.trimStart();
-            await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-            await fs.promises.writeFile(destPath, content, 'utf8');
+        try {
+          const raw = await fs.promises.readFile(sourcePath, 'utf8');
+          let content = stripFrontMatter(raw);
+          content = await inlineMdxComponents(content, context.siteDir, componentCache, path.dirname(sourcePath));
+          if (siteUrl) {
+            content = absolutizeMarkdownLinks(content, permalink, siteUrl);
+          }
+          content = content.trimStart();
+          await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
+          await fs.promises.writeFile(destPath, content, 'utf8');
 
-            // Skip twin write and tag injection for the site root: `<outDir>/.md`
-            // is nonsensical and no doc renders there in practice.
-            if (permalink === '/') return;
+          // Skip twin write and tag injection for the site root: `<outDir>/.md`
+          // is nonsensical and no doc renders there in practice.
+          if (permalink === '/') continue;
 
-            // The `.md` twin lives as a sibling of the `<outputPath>/` directory
-            // that already holds source.md, at `<outDir>/<outputPath>.md`.
-            const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
-            await fs.promises.mkdir(path.dirname(twinPath), { recursive: true });
-            await fs.promises.writeFile(twinPath, content, 'utf8');
+          // The `.md` twin lives as a sibling of the `<outputPath>/` directory
+          // that already holds source.md, at `<outDir>/<outputPath>.md`.
+          const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
+          await fs.promises.mkdir(path.dirname(twinPath), { recursive: true });
+          await fs.promises.writeFile(twinPath, content, 'utf8');
 
-            if (siteUrl) {
-              const htmlPath = path.join(outDir, outputPath, 'index.html');
-              const twinUrl = `${siteUrl}${permalink.replace(/\/$/, '')}.md`;
-              const html = await fs.promises.readFile(htmlPath, 'utf8');
-              const injected = injectAlternateLinkTag(html, twinUrl);
-              await fs.promises.writeFile(htmlPath, injected, 'utf8');
-            }
-          })
-          .catch((err) => {
-            console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
-          });
-      });
-
-      await Promise.all(writes);
+          if (siteUrl) {
+            const htmlPath = path.join(outDir, outputPath, 'index.html');
+            const twinUrl = `${siteUrl}${permalink.replace(/\/$/, '')}.md`;
+            const html = await fs.promises.readFile(htmlPath, 'utf8');
+            const injected = injectAlternateLinkTag(html, twinUrl);
+            await fs.promises.writeFile(htmlPath, injected, 'utf8');
+          }
+        } catch (err) {
+          console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
+        }
+      }
       console.log(`[copy-page-source] Wrote source.md for ${docEntries.length} pages to ${outDir}.`);
 
       // Audit: fail the build loudly if any doc is missing its twin or alternate

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -1,7 +1,7 @@
 // @ts-check
 /**
  * Docusaurus plugin that writes each doc's raw MDX source (front matter
- * stripped) to `build/<permalink>/source.md` during the build.
+ * stripped) to `build/<permalink>.md` during the build.
  *
  * The "Copy page as Markdown" button in CopyContents/index.tsx fetches this
  * file instead of scraping the rendered HTML, which preserves Mermaid diagrams,
@@ -360,7 +360,7 @@ module.exports = function copyPageSourcePlugin(context) {
 
     async postBuild({ outDir }) {
       if (docEntries.length === 0) {
-        console.warn('[copy-page-source] No docs were captured; skipping source.md writes.');
+        console.warn('[copy-page-source] No docs were captured; skipping .md writes.');
         return;
       }
 
@@ -376,8 +376,10 @@ module.exports = function copyPageSourcePlugin(context) {
 
       // Sequential so the shared componentCache is never read mid-update.
       for (const { permalink, sourcePath } of docEntries) {
+        // No .md file for the site root: `<outDir>/.md` is nonsensical.
+        if (permalink === '/') continue;
         const outputPath = toOutputPath(permalink);
-        const destPath = path.join(outDir, outputPath, 'source.md');
+        const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
         try {
           const raw = await fs.promises.readFile(sourcePath, 'utf8');
           let content = stripFrontMatter(raw);
@@ -388,16 +390,6 @@ module.exports = function copyPageSourcePlugin(context) {
           content = content.trimStart();
           // Ensure headings are preceded by a blank line (MDX doesn't require it, Markdown does).
           content = content.replace(/([^\n])\n(#{1,6} )/g, '$1\n\n$2');
-          await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
-          await fs.promises.writeFile(destPath, content, 'utf8');
-
-          // Skip twin write and tag injection for the site root: `<outDir>/.md`
-          // is nonsensical and no doc renders there in practice.
-          if (permalink === '/') continue;
-
-          // The `.md` twin lives as a sibling of the `<outputPath>/` directory
-          // that already holds source.md, at `<outDir>/<outputPath>.md`.
-          const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
           await fs.promises.mkdir(path.dirname(twinPath), { recursive: true });
           await fs.promises.writeFile(twinPath, content, 'utf8');
 
@@ -412,7 +404,7 @@ module.exports = function copyPageSourcePlugin(context) {
           console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
         }
       }
-      console.log(`[copy-page-source] Wrote source.md for ${docEntries.length} pages to ${outDir}.`);
+      console.log(`[copy-page-source] Wrote .md files for ${docEntries.length} pages to ${outDir}.`);
 
       // Audit: fail the build loudly if any doc is missing its twin or alternate
       // tag. The dominant failure mode of this feature is silent drift as new

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -16,7 +16,7 @@
  *
  * MDX component inlining: When a doc imports a local `.mdx` component (e.g.
  * `import Foo from '/src/components/en-us/_foo.mdx'`) and uses it as a JSX
- * self-closing tag (e.g. `<Foo bar="baz" />`), this plugin reads the component
+ * self-closing tag (e.g., `<Foo bar="baz" />`), this plugin reads the component
  * file, substitutes `{props.bar}` with `"baz"`, and replaces the JSX tag with
  * the inlined content. This ensures the copied Markdown is fully readable
  * outside Docusaurus (e.g., admonitions from `_warning-*.mdx` are inlined as
@@ -44,7 +44,7 @@ function stripFrontMatter(content) {
 /**
  * Resolve a path (possibly `@site/`-prefixed or root-relative `/src/...`) to an
  * absolute filesystem path.
- * @param {string} importPath  e.g. "/src/components/en-us/_foo.mdx"
+ * @param {string} importPath  e.g., "/src/components/en-us/_foo.mdx"
  * @param {string} siteDir     absolute path to the Docusaurus site root
  * @returns {string}
  */
@@ -84,6 +84,24 @@ function stripDocExtension(pathname) {
 function normalizeDocPathname(pathname) {
   const collapsed = pathname.replace(/\/(?:index|README)$/i, '');
   return collapsed || '/';
+}
+
+/**
+ * Insert a `<link rel="alternate" type="text/markdown">` tag immediately before
+ * `</head>` in the given HTML string.
+ *
+ * @param {string} html
+ * @param {string} twinUrl  Absolute URL of the `.md` twin.
+ * @returns {string}
+ * @throws {Error} if the input contains no `</head>`.
+ */
+function injectAlternateLinkTag(html, twinUrl) {
+  const tag = `<link rel="alternate" type="text/markdown" href="${twinUrl}">`;
+  const injected = html.replace(/<\/head>/i, `  ${tag}\n</head>`);
+  if (injected === html) {
+    throw new Error('No </head> tag found in HTML.');
+  }
+  return injected;
 }
 
 /**
@@ -165,7 +183,7 @@ function absolutizeMarkdownLinks(markdown, permalink, siteUrl) {
     if (inFence) return line;
 
     // Matches inline markdown links/images with destinations that don't contain whitespace.
-    // Titles are uncommon in this docs set; we keep this intentionally strict to avoid over-rewriting.
+    // Titles are uncommon in this docs set; this is intentionally strict to avoid over-rewriting.
     return line.replace(/(!?\[[^\]]*\])\((<[^>]+>|[^\s)]+)\)/g, (_match, text, dest) => {
       const normalizedDest = absolutizeDestination(dest, pageUrl, siteOrigin);
       return `${text}(${normalizedDest})`;
@@ -214,7 +232,7 @@ async function inlineMdxComponents(source, siteDir, cache) {
       } else {
         body = await fs.promises.readFile(filePath, 'utf8');
         body = stripFrontMatter(body);
-        // Strip nested import lines (for example `import Tabs from '@theme/Tabs'`)
+        // Strip nested import lines (e.g., `import Tabs from '@theme/Tabs'`)
         // so the inlined content doesn't contain unresolvable MDX imports.
         body = body.replace(
           /^import\s+[A-Za-z0-9_{}, *]+\s+from\s+['"][^'"]+['"]\s*;?\s*\n?/gm,
@@ -233,18 +251,18 @@ async function inlineMdxComponents(source, siteDir, cache) {
   //    inlined component body (props substituted). Handles optional line breaks
   //    inside the tag (multi-line attribute lists).
   //    Regex breakdown:
-  //      <ComponentName   - opening
-  //      ([\s\S]*?)       - any attributes (non-greedy, allows newlines)
-  //      \s*\/>           - self-closing
+  //      <ComponentName   — opening
+  //      ([\s\S]*?)       — any attributes (non-greedy, allows newlines)
+  //      \s*\/>           — self-closing
   for (const [name, body] of componentBodies) {
-    // Escape the component name for use in a regex.
+    // Escape the component name for use in a regex
     const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const tagRegex = new RegExp(
       `<${escapedName}([\\s\\S]*?)\\s*\\/>`,
       'g',
     );
     source = source.replace(tagRegex, (_fullMatch, propsStr) => {
-      // Parse prop values: key="value" (double-quoted only).
+      // Parse prop values: key="value" (double-quoted only)
       /** @type {Record<string, string>} */
       const props = {};
       const propRegex = /([A-Za-z0-9_]+)="([^"]*)"/g;
@@ -252,7 +270,7 @@ async function inlineMdxComponents(source, siteDir, cache) {
       while ((pm = propRegex.exec(propsStr)) !== null) {
         props[pm[1]] = pm[2];
       }
-      // Substitute {props.key} -> value.
+      // Substitute {props.key} → value
       return body.replace(
         /\{props\.([A-Za-z0-9_]+)\}/g,
         (_, key) => props[key] ?? `{props.${key}}`,
@@ -296,10 +314,10 @@ module.exports = function copyPageSourcePlugin(context) {
     /**
      * allContentLoaded is the only lifecycle hook that receives allContent
      * (the loaded content from every other plugin, including the docs plugin).
-     * We capture the permalink -> source path mapping here for use in postBuild.
+     * We capture the permalink → source path mapping here for use in postBuild.
      */
     async allContentLoaded({ allContent }) {
-      // The docs plugin can register multiple instances (for example, per locale).
+      // The docs plugin can register multiple instances (e.g., per locale).
       const docsInstances = allContent?.['docusaurus-plugin-content-docs'];
 
       if (!docsInstances || typeof docsInstances !== 'object') {
@@ -339,11 +357,16 @@ module.exports = function copyPageSourcePlugin(context) {
 
       const localeDir = path.basename(outDir);
 
-      const writes = docEntries.map(({ permalink, sourcePath }) => {
+      /** Strip the leading locale prefix from a permalink to get the output-relative path. */
+      const toOutputPath = (permalink) => {
         const permalinkPath = permalink.replace(/^\//, '');
-        const outputPath = permalinkPath.startsWith(`${localeDir}/`)
+        return permalinkPath.startsWith(`${localeDir}/`)
           ? permalinkPath.slice(localeDir.length + 1)
           : permalinkPath;
+      };
+
+      const writes = docEntries.map(({ permalink, sourcePath }) => {
+        const outputPath = toOutputPath(permalink);
         const destPath = path.join(outDir, outputPath, 'source.md');
         return fs.promises
           .readFile(sourcePath, 'utf8')
@@ -356,6 +379,24 @@ module.exports = function copyPageSourcePlugin(context) {
             content = content.trimStart();
             await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
             await fs.promises.writeFile(destPath, content, 'utf8');
+
+            // Skip twin write and tag injection for the site root: `<outDir>/.md`
+            // is nonsensical and no doc renders there in practice.
+            if (permalink === '/') return;
+
+            // The `.md` twin lives as a sibling of the `<outputPath>/` directory
+            // that already holds source.md, at `<outDir>/<outputPath>.md`.
+            const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
+            await fs.promises.mkdir(path.dirname(twinPath), { recursive: true });
+            await fs.promises.writeFile(twinPath, content, 'utf8');
+
+            if (siteUrl) {
+              const htmlPath = path.join(outDir, outputPath, 'index.html');
+              const twinUrl = `${siteUrl}${permalink.replace(/\/$/, '')}.md`;
+              const html = await fs.promises.readFile(htmlPath, 'utf8');
+              const injected = injectAlternateLinkTag(html, twinUrl);
+              await fs.promises.writeFile(htmlPath, injected, 'utf8');
+            }
           })
           .catch((err) => {
             console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
@@ -364,6 +405,48 @@ module.exports = function copyPageSourcePlugin(context) {
 
       await Promise.all(writes);
       console.log(`[copy-page-source] Wrote source.md for ${docEntries.length} pages to ${outDir}.`);
+
+      // Audit: fail the build loudly if any doc is missing its twin or alternate
+      // tag. The dominant failure mode of this feature is silent drift as new
+      // pages/locales/versions are added; the audit turns that into a CI failure
+      // on the introducing PR.
+      if (!siteUrl) {
+        console.warn('[copy-page-source] siteConfig.url is not set; skipping twin/tag audit.');
+        return;
+      }
+
+      const failures = [];
+      for (const { permalink } of docEntries) {
+        if (permalink === '/') continue;
+        const outputPath = toOutputPath(permalink);
+        const twinPath = path.join(outDir, outputPath.replace(/\/$/, '') + '.md');
+        const htmlPath = path.join(outDir, outputPath, 'index.html');
+        const twinUrl = `${siteUrl}${permalink.replace(/\/$/, '')}.md`;
+        const expectedTag = `<link rel="alternate" type="text/markdown" href="${twinUrl}">`;
+
+        try {
+          await fs.promises.access(twinPath, fs.constants.F_OK);
+        } catch {
+          failures.push(`Missing .md twin: ${twinPath}`);
+        }
+
+        try {
+          const html = await fs.promises.readFile(htmlPath, 'utf8');
+          if (!html.includes(expectedTag)) {
+            failures.push(`Missing alternate tag in ${htmlPath} (expected href=${twinUrl})`);
+          }
+        } catch (err) {
+          failures.push(`Cannot read ${htmlPath}: ${err.message}`);
+        }
+      }
+
+      if (failures.length > 0) {
+        const summary = failures.map((f) => `  - ${f}`).join('\n');
+        throw new Error(
+          `[copy-page-source] Build audit failed for ${failures.length} entr${failures.length === 1 ? 'y' : 'ies'}:\n${summary}`,
+        );
+      }
+      console.log(`[copy-page-source] Audit passed: ${docEntries.length} entries have twin + alternate tag.`);
     },
   };
 };

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -98,8 +98,9 @@ function normalizeDocPathname(pathname) {
  * @throws {Error} if the input contains no `</head>`.
  */
 function injectAlternateLinkTag(html, twinUrl) {
+  const comment = `<!-- AI/LLM agents: a clean Markdown version of this page is available at ${twinUrl} -->`;
   const tag = `<link rel="alternate" type="text/markdown" href="${twinUrl}">`;
-  const injected = html.replace(/<\/head>/i, `  ${tag}\n</head>`);
+  const injected = html.replace(/<\/head>/i, `  ${comment}\n  ${tag}\n</head>`);
   if (injected === html) {
     throw new Error('No </head> tag found in HTML.');
   }

--- a/src/plugins/copy-page-source.js
+++ b/src/plugins/copy-page-source.js
@@ -374,6 +374,8 @@ module.exports = function copyPageSourcePlugin(context) {
           : permalinkPath;
       };
 
+      /** @type {Set<string>} Permalinks whose HTML was successfully tagged; used by the audit to skip re-reads. */
+      const tagInjected = new Set();
       // Sequential so the shared componentCache is never read mid-update.
       for (const { permalink, sourcePath } of docEntries) {
         // No .md file for the site root: `<outDir>/.md` is nonsensical.
@@ -399,9 +401,10 @@ module.exports = function copyPageSourcePlugin(context) {
             const html = await fs.promises.readFile(htmlPath, 'utf8');
             const injected = injectAlternateLinkTag(html, twinUrl);
             await fs.promises.writeFile(htmlPath, injected, 'utf8');
+            tagInjected.add(permalink);
           }
         } catch (err) {
-          console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err.message}`);
+          console.warn(`[copy-page-source] Skipping ${sourcePath}: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
       console.log(`[copy-page-source] Wrote .md files for ${docEntries.length} pages to ${outDir}.`);
@@ -430,13 +433,15 @@ module.exports = function copyPageSourcePlugin(context) {
           failures.push(`Missing .md twin: ${twinPath}`);
         }
 
-        try {
-          const html = await fs.promises.readFile(htmlPath, 'utf8');
-          if (!html.includes(expectedTag)) {
-            failures.push(`Missing alternate tag in ${htmlPath} (expected href=${twinUrl})`);
+        if (!tagInjected.has(permalink)) {
+          try {
+            const html = await fs.promises.readFile(htmlPath, 'utf8');
+            if (!html.includes(expectedTag)) {
+              failures.push(`Missing alternate tag in ${htmlPath} (expected href=${twinUrl})`);
+            }
+          } catch (err) {
+            failures.push(`Cannot read ${htmlPath}: ${err instanceof Error ? err.message : String(err)}`);
           }
-        } catch (err) {
-          failures.push(`Cannot read ${htmlPath}: ${err.message}`);
         }
       }
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: */source.md
+Disallow: /*.md$

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /*.md$
+Disallow: /*.md

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,2 @@
 User-agent: *
-Disallow: */source.md
 Disallow: /*.md$


### PR DESCRIPTION
## Description

This PR makes every doc page fetchable as clean Markdown by appending `.md` to its URL, and advertises that URL to AI agents and LLM crawlers via a `<link rel="alternate" type="text/markdown">` tag plus a plain-text HTML comment fallback. The "Copy page as Markdown" button is updated to fetch from the same `<PERMALINK>.md` URL, replacing the previous `<PERMALINK>/source.md` pattern and eliminating duplicate files. A build-time audit fails CI if any doc page is missing its `.md` file or its alternate tag.

## Related issues and/or PRs

Similar enhancement made to the ScalarDL docs site:

- https://github.com/scalar-labs/docs-scalardb/pull/2437

## Changes made

**Single `.md` file per page**

- The plugin writes each doc's processed Markdown to `build/<PERMALINK>.md` (front-matter stripped, MDX components inlined, links absolutized). The previous `<PERMALINK>/source.md` file is removed; `CopyContents/index.tsx` now fetches `<PERMALINK>.md` directly.

**AI agent discoverability**

- Injects `<link rel="alternate" type="text/markdown" href="<PERMALINK>.md">` into every doc page's `<head>`, preceded by `<!-- AI/LLM agents: a clean Markdown version of this page is available at <URL> -->` as a plain-text fallback for agents that don't recognize the `rel="alternate"` convention.

**Build-time audit**

- After generating files and injecting tags, the plugin verifies every doc page (except the site root) has a `.md` file and the alternate tag. The build fails with a clear error listing any offenders.

**`robots.txt`**

- `Disallow: /*.md$` blocks search-engine crawlers from indexing .md files as duplicate content. On-demand fetches by the button and by AI agents following the alternate tag are unaffected—`robots.txt` governs autonomous crawling only.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A