### PR TITLE
Change Context7 refresh schedule to Sunday

### DIFF
--- a/.github/workflows/refresh-context7-sources.yml
+++ b/.github/workflows/refresh-context7-sources.yml
@@ -2,7 +2,7 @@ name: Refresh Context7 library (llms-full.txt)
 
 on:
   schedule:
-    - cron: "0 0 * * 1" # Run every Monday at 00:00 UTC (9:00 AM JST).
+    - cron: "0 0 * * 0" # Run every Sunday at 00:00 UTC (9:00 AM JST).
   workflow_dispatch:
     inputs:
       library_name:


### PR DESCRIPTION
## Description

This PR updates the schedule for the `refresh-context7-sources.yml` GitHub Actions workflow. This is needed because the ScalarDB source update in Context7, triggered by [this workflow](https://github.com/scalar-labs/docs-scalardb/blob/8bb9295f8fbd8a042360ebb5a3e70f8c4e5dfa47/.github/workflows/refresh-context7-sources.yml) has started to run longer (previously it was 2.5 hours but recently, it's taken 6+ hours) on Monday mornings, which causes the Context7 workflow for the ScalarDL docs site content to fail. The reason for the failed source update in Context7 for the ScalarDL docs site content is because only one library can be processed at a time in Context7.

The change made in this PR to this workflow will cause it to run on Sunday mornings instead of Monday mornings, which should give Context7 ample time to finish processing the ScalarDL docs, which typically takes less time because there are fewer docs than the ScalarDB docs site, before the ScalarDB docs site content is schedule to run on Monday mornings.

## Related issues and/or PRs

N/A

## Changes made

- Updated the cron schedule in `.github/workflows/refresh-context7-sources.yml` to run every Sunday at 00:00 UTC (Sunday at 9:00 AM JST) instead of Monday at 00:00 UTC (Monday at 9:00 AM JST).

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A