### PR TITLE
Change "Try Now" CTA button to point to Quickstart overview

### DIFF
--- a/src/theme/Navbar/Search/index.tsx
+++ b/src/theme/Navbar/Search/index.tsx
@@ -21,7 +21,7 @@ export default function SearchWrapper(props: Props): ReactNode {
       <Search {...props} />
       <GoogleAIModeSearch />
       <div>
-        <a href={`${locale}/docs/${version}/scalar-licensing/trial`} className="navbar__link--cta">{tryNowLabel}</a>
+        <a href={`${locale}/docs/${version}/quickstart-overview`} className="navbar__link--cta">{tryNowLabel}</a>
       </div>
     </>
   );


### PR DESCRIPTION
## Description

This PR changes the destination of the "Try Now" call-to-action button in the heading navigation from the trial-licensing page to the quickstart overview, which lists the getting started tutorials.

To check the behavior of the link, see the following staging site: https://6a9fa400e51d8ab22fb79520--scalardl-try-now-link-to-quickstart.netlify.app/

## Related issues and/or PRs

- **Jira story:** https://scalar-labs.atlassian.net/browse/DLT-19593
- **ScalarDB docs site PR:**
  - https://github.com/scalar-labs/docs-scalardb/pull/2593

## Changes made

- Change the URL of the "Try Now" button from the `scalar-licensing/trial` page to the `quickstart-overview` page.

## Checklist

> The following is a best-effort checklist. If any items in this checklist are not applicable to this PR or are dependent on other, unmerged PRs, please still mark the checkboxes after you have read and understood each item.

- [x] I have updated the side navigation as necessary. If this PR introduces a new doc, I have added `[NEW]` to the:
  - [x] Relevant sidebar `label` entries in `sidebars.js` (latest).
  - [x] Appropriate `versioned_sidebars/version-X.Y-sidebars.json`, and to any corresponding label strings in the **Recent Features** docs under `src/components/Cards/` (and `src/components/Cards/ja-jp/` for Japanese).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes.
- [x] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] My changes generate no new warnings.
- [x] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

N/A